### PR TITLE
[Feature] sidebar always expanded

### DIFF
--- a/atomic_defi_design/Dex/Sidebar/Main.qml
+++ b/atomic_defi_design/Dex/Sidebar/Main.qml
@@ -17,7 +17,7 @@ Item
         Support
     }
 
-    property bool   isExpanded: containsMouse
+    property bool   isExpanded: true
     property real   lineHeight: 44
     property var    currentLineType: Main.LineType.Portfolio
     property alias  _selectionCursor: _selectionCursor

--- a/src/core/atomicdex/api/mm2/rpc2.enable_tendermint_token.hpp
+++ b/src/core/atomicdex/api/mm2/rpc2.enable_tendermint_token.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include <nlohmann/json_fwd.hpp> //> nlohmann::json


### PR DESCRIPTION
This pull request ensures that the left sidebar is always expanded, regardless of the mouse position. In my opinion, this is a beneficial improvement to the GUI because changing the size of the left sidebar while moving the mouse can be quite annoying.

![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/22120003/2dcf2d56-d21e-4260-a2d8-7075bb419af5)
