### PR TITLE
fix GLIBC error

### DIFF
--- a/ci_tools_atomic_dex/ci_scripts/linux_script.sh
+++ b/ci_tools_atomic_dex/ci_scripts/linux_script.sh
@@ -2,8 +2,8 @@
 
 sudo apt-get update  # prevents repo404 errors on apt-remove below
 sudo apt-get remove php* msodbcsql17 mysql*
-sudo apt-get update
-sudo ACCEPT_EULA=Y apt-get upgrade -y
+#sudo apt-get update
+#sudo ACCEPT_EULA=Y apt-get upgrade -y
 # base deps
 sudo apt-get install build-essential \
                     libgl1-mesa-dev \


### PR DESCRIPTION
fix error with debian 11 and other older linux versions
```
AntaraAtomicDexAppDir/usr/bin/komodo-wallet: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: versionGLIBCXX_3.4.30' not found (required by AntaraAtomicDexAppDir/usr/bin/komodo-wallet)
```