### PR TITLE
dont close notifications when marking all as read

### DIFF
--- a/atomic_defi_design/Dex/Dashboard/NotificationsModal.qml
+++ b/atomic_defi_design/Dex/Dashboard/NotificationsModal.qml
@@ -32,10 +32,11 @@ DexPopup
 
     readonly property string check_internet_connection_text: qsTr("Please check your internet connection (e.g. VPN service or firewall might block it).")
 
-    function reset()
+    function reset(close_after_reset = false)
     {
         notifications_list = []
-        root.close()
+        if (close_after_reset)
+            root.close()
     }
 
     enum NotificationKind
@@ -619,7 +620,7 @@ DexPopup
             height: 40
             width: 260
             Layout.alignment: Qt.AlignHCenter
-            onClicked: root.reset()
+            onClicked: notifications_list.length !== 0 ? root.reset(false) : root.reset(true)
         }
     }
 }


### PR DESCRIPTION
Closes: https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2305

To test:
- perform an action which will add a notification to the list (e.g. enable zhtlc coin)
- open notifications, and click the "mark all as read" button
- confirm notifications area remains open, and button changes to "close"
- click close button
- confirm notifications area closes.