### PR TITLE
update addressbook tags

### DIFF
--- a/assets/themes/Binance - Dark/colors.json
+++ b/assets/themes/Binance - Dark/colors.json
@@ -122,7 +122,7 @@
   "listItemEvenBackground": "#161515",
   "listItemHoveredBackground": "#5B4704",
   
-  "addressBookTagColors": ["#627EEA", "#FFD87A", "#F7931A"],
+  "addressBookTagColors": ["#003bbbFF", "#006133FF", "#612600FF", "#430061FF", "#004d61FF"],
   
   "okColor": "#00C058",
   "warningColor": "#E52167",

--- a/assets/themes/Default - Dark/colors.json
+++ b/assets/themes/Default - Dark/colors.json
@@ -121,8 +121,7 @@
     "listItemEvenBackground": "#24273DFF",
     "listItemHoveredBackground": "#4068B9FF",
 
-
-    "addressBookTagColors": ["#627EEAFF", "#FFD87AFF", "#F7931AFF"],
+    "addressBookTagColors": ["#003bbbFF", "#006133FF", "#612600FF", "#430061FF", "#004d61FF"],
 
     "okColor": "#00C058FF",
     "warningColor": "#E52167FF",

--- a/assets/themes/Default - Light/colors.json
+++ b/assets/themes/Default - Light/colors.json
@@ -119,7 +119,7 @@
     "listItemEvenBackground": "#EDF4FFFF",
     "listItemHoveredBackground": "#D7E7FFFF",
 
-    "addressBookTagColors": ["#627EEAFF", "#FFD87AFF", "#F7931AFF"],
+    "addressBookTagColors": ["#003bbbFF", "#006133FF", "#612600FF", "#430061FF", "#004d61FF"],
 
     "okColor": "#00C058FF",
     "warningColor": "#E52167FF",

--- a/atomic_defi_design/Dex/Addressbook/AddAddressForm.qml
+++ b/atomic_defi_design/Dex/Addressbook/AddAddressForm.qml
@@ -195,7 +195,7 @@ Dex.Rectangle
                 Layout.preferredWidth: 116
                 Layout.preferredHeight: 38
                 radius: 18
-                text: isConvertMode ? qsTr("Convert") : editionMode ? qsTr("Edit") : qsTr("Add")
+                text: isConvertMode ? qsTr("Convert") : editionMode ? qsTr("Update") : qsTr("Save")
                 onClicked:
                 {
                     let addressType = getTypeForAddressChecker(addressTypeComboBox.currentText)

--- a/atomic_defi_design/Dex/Addressbook/AddTagPopup.qml
+++ b/atomic_defi_design/Dex/Addressbook/AddTagPopup.qml
@@ -13,6 +13,7 @@ Dex.Popup
     width: 250
     height: 55
 
+    onOpened: tagNameField.forceActiveFocus()
     onClosed: tagNameField.text = ""
 
     contentItem: Row
@@ -22,9 +23,16 @@ Dex.Popup
         Dex.TextField
         {
             id: tagNameField
+            visible: contactModel.categories.length < 5
             width: parent.width * 0.6
             height: parent.height
             placeholderText: qsTr("Tag name")
+
+            onTextChanged: {
+                if(text.length > 10) {
+                    text = text.substring(0, 10)
+                }
+            }
 
             Dex.ToolTip
             {
@@ -40,6 +48,7 @@ Dex.Popup
 
         Dex.Button
         {
+            visible: contactModel.categories.length < 5
             width: parent.width * 0.36
             height: parent.height
             text: qsTr("+ ADD")
@@ -56,5 +65,16 @@ Dex.Popup
                 else root.close()
             }
         }
+
+        Dex.Text
+        {
+            id: tagLimitText
+            visible: contactModel.categories.length > 4
+            width: parent.width * 0.6
+            height: parent.height
+            color: Style.colorRed
+            text: qsTr("A contact can only have 5 tags.")
+        }
+        
     }
 }

--- a/atomic_defi_design/Dex/Addressbook/EditContactModal.qml
+++ b/atomic_defi_design/Dex/Addressbook/EditContactModal.qml
@@ -234,17 +234,19 @@ Dex.MultipageModal
                     Dex.Rectangle
                     {
                         id: tagBg
+                        property int _currentColorIndex: contactTable._getCurrentTagColorId()
                         anchors.verticalCenter: parent.verticalCenter
                         width: tagLabel.width + 12
                         height: 21
                         radius: 20
-                        color: Dex.CurrentTheme.accentColor
+                        color: Dex.CurrentTheme.addressBookTagColors[_currentColorIndex]
 
                         Dex.Text
                         {
                             id: tagLabel
                             anchors.centerIn: parent
                             text: modelData
+                            color: "white"
                         }
                     }
 

--- a/atomic_defi_design/Dex/Addressbook/EditContactModal.qml
+++ b/atomic_defi_design/Dex/Addressbook/EditContactModal.qml
@@ -192,7 +192,7 @@ Dex.MultipageModal
             {
                 visible: !addressList.contactAddAddressMode
                 anchors.horizontalCenter: parent.horizontalCenter
-                text: qsTr("+ Add")
+                text: qsTr("+ Add Address")
                 width: 211
                 height: 38
                 radius: 18
@@ -224,7 +224,7 @@ Dex.MultipageModal
                 width: parent.width
                 model: contactModel.categories
                 orientation: Qt.Horizontal
-                spacing: 6
+                spacing: 4
                 delegate: Dex.MouseArea
                 {
                     width: tagBg.width + tagRemoveBut.width + 2
@@ -255,8 +255,8 @@ Dex.MultipageModal
                         anchors.left: tagBg.right
                         anchors.leftMargin: 2
                         anchors.verticalCenter: parent.verticalCenter
-                        width: 18
-                        height: 18
+                        width: 16
+                        height: 16
                         color: "transparent"
                         iconSource: Qaterial.Icons.close
                         onClicked: contactModel.removeCategory(modelData)
@@ -288,7 +288,7 @@ Dex.MultipageModal
                 Layout.preferredWidth: 199
                 Layout.preferredHeight: 48
                 radius: 18
-                text: qsTr("Cancel")
+                text: qsTr("Cancel Updates")
                 onClicked: root.close()
             },
 
@@ -299,7 +299,7 @@ Dex.MultipageModal
                 Layout.preferredWidth: 199
                 Layout.preferredHeight: 48
                 radius: 18
-                text: qsTr("Confirm")
+                text: qsTr("Save Updates")
                 onClicked:
                 {
                     contactModel.name = contactNameInput.field.text

--- a/atomic_defi_design/Dex/Addressbook/Main.qml
+++ b/atomic_defi_design/Dex/Addressbook/Main.qml
@@ -194,29 +194,29 @@ Item
                         {
                             model: modelData.categories.slice(0, 6)
 
-                            delegate: Dex.Rectangle
+                            delegate: Dex.MouseArea
                             {
-                                property int _currentColorIndex: contactTable._getCurrentTagColorId()
+                                width: tagBg.width + 2
+                                height: tagBg.height
+                                onClicked: searchbar.textField.text = modelData
+                                hoverEnabled: true
 
-                                width: tagLabel.width > 73 ? 83 : tagLabel.width + 10
-                                height: 21
-                                radius: 20
-                                color: Dex.CurrentTheme.addressBookTagColors[_currentColorIndex]
-
-                                Dex.MouseArea
+                                Dex.Rectangle
                                 {
-                                    anchors.fill: parent
-                                    onClicked: searchbar.textField.text = modelData
-                                }
+                                    id: tagBg
+                                    property int _currentColorIndex: contactTable._getCurrentTagColorId()
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    width: tagLabel.width + 12
+                                    height: 21
+                                    radius: 20
+                                    color: Dex.CurrentTheme.addressBookTagColors[_currentColorIndex]
 
-                                Dex.Text
-                                {
-                                    id: tagLabel
-                                    width: 70
-                                    anchors.centerIn: parent
-                                    text: modelData
-                                    horizontalAlignment: Text.AlignHCenter
-                                    elide: Text.ElideRight
+                                    Dex.Text
+                                    {
+                                        id: tagLabel
+                                        anchors.centerIn: parent
+                                        text: modelData
+                                    }
                                 }
                             }
                         }

--- a/atomic_defi_design/Dex/Addressbook/Main.qml
+++ b/atomic_defi_design/Dex/Addressbook/Main.qml
@@ -216,6 +216,7 @@ Item
                                         id: tagLabel
                                         anchors.centerIn: parent
                                         text: modelData
+                                        color: "white"
                                     }
                                 }
                             }

--- a/atomic_defi_design/Dex/Addressbook/NewContactPopup.qml
+++ b/atomic_defi_design/Dex/Addressbook/NewContactPopup.qml
@@ -49,7 +49,7 @@ Dex.Popup
         {
             id: add_contact_btn
             font: DexTypo.body2
-            text: qsTr("+ ADD")
+            text: qsTr("Save")
             height: 30
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked:

--- a/atomic_defi_design/Dex/Themes/DefaultTheme.js
+++ b/atomic_defi_design/Dex/Themes/DefaultTheme.js
@@ -123,7 +123,7 @@ function getHardcoded()
         listItemEvenBackground:    "#24273DFF",
         listItemHoveredBackground: "#4068B9FF",
 
-        addressBookTagColors: ["#627EEAFF", "#FFD87AFF", "#F7931AFF"],
+        addressBookTagColors: ["#003bbbFF", "#006133FF", "#612600FF", "#430061FF", "#004d61FF"],
 
         okColor: "#00C058FF",
         warningColor: "#E52167FF",


### PR DESCRIPTION
Closes: https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2311

Addressbook tags are now limited to 10 chars and 5 per contact
![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/ec08552e-10af-4345-848f-8aa50b0801e4)

A couple of buttons were renamed also for clarity.
![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/f49ee44f-33c6-45a1-9ce9-d2c2db8c14f0)
![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/63a00b37-d137-4846-8431-bdee020821f4)
![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/6046679d-6cfb-44e8-8423-e09ff34c2980)

To test:
- Add tags to a contact. You should not be able add more than 5 tags, or a tag longer than 10 letters. With all 5 tags at max length, there should be no overflows.

