### PR TITLE
Upgrade Z coin activation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,13 +60,13 @@ endif ()
 ##! We fetch our dependencies
 if (APPLE)
     FetchContent_Declare(mm2
-            URL https://github.com/KomodoPlatform/komodo-defi-framework/releases/download/v1.0.5-beta/mm2-1d8bebd15-Darwin-Release.zip)
+            URL https://sdk.devbuilds.komodo.earth/main/mm2_79f6205-mac-x86-64.zip)
 elseif (UNIX AND NOT APPLE)
     FetchContent_Declare(mm2
-            URL https://github.com/KomodoPlatform/komodo-defi-framework/releases/download/v1.0.5-beta/mm2-1d8bebd15-Linux-Release.zip)
+            URL https://sdk.devbuilds.komodo.earth/main/mm2_79f6205-linux-x86-64.zip)
 else ()
     FetchContent_Declare(mm2
-            URL https://github.com/KomodoPlatform/komodo-defi-framework/releases/download/v1.0.5-beta/mm2-1d8bebd15-Win64.zip)
+            URL https://sdk.devbuilds.komodo.earth/main/mm2_79f6205-win-x86-64.zip)
 endif ()
 
 #FetchContent_Declare(qmaterial URL https://github.com/KomodoPlatform/Qaterial/archive/last-clang-working-2.zip)

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -119,13 +119,11 @@ QtObject {
 
     function zhtlcActivationProgress(activation_status, coin='ARRR')
     {
-        // Around 90 mins for ARRR when using 'earliest' activation
-        // and params set as below
-        // j["params"]["activation_params"]["scan_blocks_per_iteration"] = 1000;
-        // j["params"]["activation_params"]["scan_interval_ms"]          = 200;
-
         const coin_info = API.app.portfolio_pg.global_cfg_mdl.get_coin_info(coin)
         let block_offset = coin_info.checkpoint_block
+        if (coin_info.ticker.toString() == "ARRR") {
+            block_offset = API.app.settings_pg.get_pirate_sync_block()
+        }
         let progress = 100
         if (!activation_status.hasOwnProperty("result")) return progress
         // console.log("["+coin+"] [zhtlcActivationProgress]: " + JSON.stringify(activation_status))

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -144,17 +144,19 @@ QtObject {
         {
             if (details.hasOwnProperty("UpdatingBlocksCache"))
             {
+                block_offset = details.UpdatingBlocksCache.first_sync_block.actual
                 let n = details.UpdatingBlocksCache.current_scanned_block - block_offset
                 let d = details.UpdatingBlocksCache.latest_block - block_offset
-                progress = 5 + parseInt(n/d*15)
+                progress = 5 + parseInt(n/d*40)
             }
             else if (details.hasOwnProperty("BuildingWalletDb"))
             {
+                block_offset = details.BuildingWalletDb.first_sync_block.actual
                 let n = details.BuildingWalletDb.current_scanned_block - block_offset
                 let d = details.BuildingWalletDb.latest_block - block_offset
-                progress = 20 + parseInt(n/d*80)
+                progress = 45 + parseInt(n/d*40)
             }
-            else if (details.hasOwnProperty("RequestingBalance")) progress = 98
+            else if (details.hasOwnProperty("RequestingBalance")) progress = 95
             else if (details.hasOwnProperty("ActivatingCoin")) progress = 5
             else progress = 5
         }

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -119,14 +119,18 @@ QtObject {
 
     function zhtlcActivationProgress(activation_status, coin='ARRR')
     {
+        // Around 90 mins for ARRR when using 'earliest' activation
+        // and params set as below
+        // j["params"]["activation_params"]["scan_blocks_per_iteration"] = 1000;
+        // j["params"]["activation_params"]["scan_interval_ms"]          = 200;
+
+        const coin_info = API.app.portfolio_pg.global_cfg_mdl.get_coin_info(coin)
+        let block_offset = coin_info.checkpoint_block
         let progress = 100
         if (!activation_status.hasOwnProperty("result")) return progress
         // console.log("["+coin+"] [zhtlcActivationProgress]: " + JSON.stringify(activation_status))
         let status = activation_status.result.status
         let details = activation_status.result.details
-
-        let block_offset = 0
-        if (coin == 'ARRR') block_offset = 2000000
 
         // use range from checkpoint block to present
         if (!status)
@@ -153,6 +157,7 @@ QtObject {
                 progress = 20 + parseInt(n/d*80)
             }
             else if (details.hasOwnProperty("RequestingBalance")) progress = 98
+            else if (details.hasOwnProperty("ActivatingCoin")) progress = 5
             else progress = 5
         }
         else console.log("["+coin+"] [zhtlcActivationProgress] Unexpected status: " + status)

--- a/atomic_defi_design/Dex/Settings/SettingModal.qml
+++ b/atomic_defi_design/Dex/Settings/SettingModal.qml
@@ -298,6 +298,52 @@ Qaterial.Dialog
                                 onClicked: openLogsFolder()
                             }
 
+                            // Notifications toggle
+                            RowLayout
+                            {
+                                width: parent.width - 30
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                height: 50
+
+                                DexLabel
+                                {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    Layout.fillWidth: true
+                                    font: DexTypo.subtitle1
+                                    text: qsTr("ARRR sync height")
+                                }
+
+                                Item { Layout.fillWidth: true }
+
+                                DexComboBox
+                                {
+                                    id: pirate_sync_combo_box
+                                    Layout.alignment: Qt.AlignVCenter
+                                    width: 140
+                                    height: 45
+                                    dropDownMaxHeight: 600
+                                    model: [
+                                        150000,
+                                        300000,
+                                        500000,
+                                        750000,
+                                        1000000,
+                                        1250000,
+                                        1500000,
+                                        1750000,
+                                        2000000,
+                                        2250000,
+                                        2500000
+                                    ]
+                                    currentIndex: model.indexOf(parseInt(atomic_settings2.value("PirateSyncHeight")))
+                                    onCurrentIndexChanged: atomic_settings2.setValue("PirateSyncHeight", model[currentIndex])
+                                    Component.onCompleted:
+                                    {
+                                        currentIndex: model.indexOf(parseInt(atomic_settings2.value("PirateSyncHeight")))
+                                    }
+                                }
+                            }
+
                             SettingsButton
                             {
                                 width: parent.width - 30

--- a/src/app/main.prerequisites.hpp
+++ b/src/app/main.prerequisites.hpp
@@ -344,6 +344,7 @@ handle_settings(QSettings& settings)
     create_settings_functor("CurrentLang", QString("en"));
     create_settings_functor("2FA", 0);
     create_settings_functor("MaximumNbCoinsEnabled", 50);
+    create_settings_functor("PirateSyncHeight", 2500000);
     create_settings_functor("DefaultTradingMode", TradingMode::Simple);
     create_settings_functor("FontMode", QQuickWindow::TextRenderType::QtTextRendering);
 }

--- a/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.cpp
+++ b/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.cpp
@@ -31,6 +31,8 @@ namespace atomic_dex::mm2
         j["params"]["activation_params"]["mode"]["rpc_data"]["sync_params"]["height"]  = request.sync_height;
         j["params"]["activation_params"]["mode"]["rpc_data"]["electrum_servers"]       = request.servers;
         j["params"]["activation_params"]["mode"]["rpc_data"]["light_wallet_d_servers"] = request.z_urls;
+        j["params"]["activation_params"]["scan_blocks_per_iteration"]                  = 5000;
+        j["params"]["activation_params"]["scan_interval"]                              = 1000;
         j["params"]["tx_history"]                                                      = request.with_tx_history;
     }
 

--- a/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.cpp
+++ b/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.cpp
@@ -28,11 +28,12 @@ namespace atomic_dex::mm2
     {
         j["params"]["ticker"]                                                          = request.coin_name;
         j["params"]["activation_params"]["mode"]["rpc"]                                = "Light";
-        j["params"]["activation_params"]["sync_params"]                                = "earliest";
+        j["params"]["activation_params"]["scan_blocks_per_iteration"]                  = 1000;
+        j["params"]["activation_params"]["scan_interval_ms"]                           = 200;
+        j["params"]["activation_params"]["mode"]["rpc_data"]["sync_params"]["height"]  = request.sync_height;
         j["params"]["activation_params"]["mode"]["rpc_data"]["electrum_servers"]       = request.servers;
         j["params"]["activation_params"]["mode"]["rpc_data"]["light_wallet_d_servers"] = request.z_urls;
         j["params"]["tx_history"]                                                      = request.with_tx_history;
-        earliest
     }
 
     //! Deserialization

--- a/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.cpp
+++ b/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.cpp
@@ -28,8 +28,6 @@ namespace atomic_dex::mm2
     {
         j["params"]["ticker"]                                                          = request.coin_name;
         j["params"]["activation_params"]["mode"]["rpc"]                                = "Light";
-        j["params"]["activation_params"]["scan_blocks_per_iteration"]                  = 1000;
-        j["params"]["activation_params"]["scan_interval_ms"]                           = 200;
         j["params"]["activation_params"]["mode"]["rpc_data"]["sync_params"]["height"]  = request.sync_height;
         j["params"]["activation_params"]["mode"]["rpc_data"]["electrum_servers"]       = request.servers;
         j["params"]["activation_params"]["mode"]["rpc_data"]["light_wallet_d_servers"] = request.z_urls;

--- a/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.cpp
+++ b/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.cpp
@@ -28,9 +28,11 @@ namespace atomic_dex::mm2
     {
         j["params"]["ticker"]                                                          = request.coin_name;
         j["params"]["activation_params"]["mode"]["rpc"]                                = "Light";
+        j["params"]["activation_params"]["sync_params"]                                = "earliest";
         j["params"]["activation_params"]["mode"]["rpc_data"]["electrum_servers"]       = request.servers;
         j["params"]["activation_params"]["mode"]["rpc_data"]["light_wallet_d_servers"] = request.z_urls;
         j["params"]["tx_history"]                                                      = request.with_tx_history;
+        earliest
     }
 
     //! Deserialization

--- a/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.hpp
+++ b/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.hpp
@@ -34,6 +34,7 @@ namespace atomic_dex::mm2
         std::vector<atomic_dex::electrum_server>  servers;
         std::vector<std::string>                  z_urls;
         CoinType                                  coin_type;
+        int                                       sync_height{1000};
         bool                                      is_testnet{false};
         bool                                      with_tx_history{false};  // Not yet in API
     };

--- a/src/core/atomicdex/config/coins.cfg.cpp
+++ b/src/core/atomicdex/config/coins.cfg.cpp
@@ -168,6 +168,7 @@ namespace atomic_dex
         cfg.wallet_only          = is_wallet_only(cfg.ticker) ? is_wallet_only(cfg.ticker) : j.contains("wallet_only") ? j.at("wallet_only").get<bool>() : false;
         cfg.default_coin         = is_default_coin(cfg.ticker);
         cfg.is_faucet_coin       = is_faucet_coin(cfg.ticker);
+        cfg.checkpoint_block     = 0;
 
         if (j.contains("other_types"))
         {
@@ -224,7 +225,12 @@ namespace atomic_dex
         if (j.contains("light_wallet_d_servers"))
         {
             cfg.z_urls = j.at("light_wallet_d_servers").get<std::vector<std::string>>();
-        }        if (j.contains("alias_ticker"))
+        }
+        if (j.contains("check_point_block"))
+        {
+            cfg.checkpoint_block = j.at("check_point_block").get<int>();
+        }
+        if (j.contains("alias_ticker"))
         {
             cfg.alias_ticker = j.at("alias_ticker").get<std::string>();
         }

--- a/src/core/atomicdex/config/coins.cfg.hpp
+++ b/src/core/atomicdex/config/coins.cfg.hpp
@@ -55,6 +55,7 @@ namespace atomic_dex
         std::string                                       minimal_claim_amount{"0"};
         CoinType                                          coin_type;
         nlohmann::json                                    activation_status;
+        int                                               checkpoint_block{0};
         bool                                              segwit{false};
         bool                                              active{false};
         bool                                              checked{false};

--- a/src/core/atomicdex/models/qt.global.coins.cfg.model.cpp
+++ b/src/core/atomicdex/models/qt.global.coins.cfg.model.cpp
@@ -46,6 +46,7 @@ namespace
             {"is_testnet", coin.is_testnet.value_or(false)},
             {"is_erc_family", coin.is_erc_family},
             {"is_zhtlc_family", coin.is_zhtlc_family},
+            {"checkpoint_block", coin.checkpoint_block},
             {"is_wallet_only", coin.wallet_only},
             {"has_memos", coin.has_memos},
             {"fees_ticker", QString::fromStdString(coin.fees_ticker)}};

--- a/src/core/atomicdex/pages/qt.settings.page.cpp
+++ b/src/core/atomicdex/pages/qt.settings.page.cpp
@@ -79,6 +79,19 @@ namespace atomic_dex { void settings_page::update() {} }
 // Getters|Setters
 namespace atomic_dex
 {
+    int settings_page::get_pirate_sync_block() const
+    {
+        QSettings& settings = entity_registry_.ctx<QSettings>();
+        return settings.value("PirateSyncHeight").toInt();
+    }
+
+    void settings_page::set_pirate_sync_block(int new_height)
+    {
+        QSettings&        settings     = entity_registry_.ctx<QSettings>();
+        settings.setValue("PirateSyncHeight", new_height);
+        settings.sync();
+    }
+
     QString settings_page::get_current_lang() const
     {
         QSettings& settings = entity_registry_.ctx<QSettings>();

--- a/src/core/atomicdex/pages/qt.settings.page.hpp
+++ b/src/core/atomicdex/pages/qt.settings.page.hpp
@@ -81,6 +81,7 @@ namespace atomic_dex
         [[nodiscard]] QString                   get_current_currency_sign() const;
         [[nodiscard]] QString                   get_current_fiat_sign() const;
         [[nodiscard]] QString                   get_current_fiat() const;
+        void                                    set_pirate_sync_block(int new_height);
         [[nodiscard]] bool                      is_notification_enabled() const;
         void                                    set_notification_enabled(bool is_enabled);
         [[nodiscard]] bool                      is_spamfilter_enabled() const;
@@ -108,6 +109,7 @@ namespace atomic_dex
         Q_INVOKABLE [[nodiscard]] bool          is_this_ticker_present_in_raw_cfg(const QString& ticker) const;
         Q_INVOKABLE [[nodiscard]] bool          is_this_ticker_present_in_normal_cfg(const QString& ticker) const;
         Q_INVOKABLE [[nodiscard]] QString       get_custom_coins_icons_path() const;
+        Q_INVOKABLE [[nodiscard]] int           get_pirate_sync_block() const;
         Q_INVOKABLE void                        process_token_add(const QString& contract_address, const QString& coingecko_id, const QString& icon_filepath, CoinType coin_type);
         Q_INVOKABLE void                        process_qrc_20_token_add(const QString& contract_address, const QString& coingecko_id, const QString& icon_filepath);
         Q_INVOKABLE void                        submit();


### PR DESCRIPTION
ref: https://github.com/KomodoPlatform/komodo-defi-framework/pull/1922
closes: https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2354

This PR introduces the `sync_params` feature in the newly released 1.0.7 API. This allows the user to specify which block to begin sync from - previously it was hardcoded as block 1900000 (for ARRR).

After this PR is merged it will use the block height selected by the user in settings, and where the setting does not exist (e.g. for zombie) it will use the checkpoint block from coins_config.json

![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/d7e223e2-aa5a-4e47-b69b-7c3c59faf37f)

To test:
- From a clean wallet, activate ARRR.
- Confirm progress % is sane. 
- Select an earlier block from the settings, then restart app and try to activate again. The sync block value should appear in logs like `"first_sync_block":{"actual":1500000,"is_pre_sapling":false,"requested":1500000}`. You dont need to wait for full sync (it takes a long time), just confirm in logs.
- From an older wallet, repeat the above steps.

Note: Balance from transactions prior to the sync block will not be visible / included. 