### PR TITLE
Use rounded derived height sync param

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ FetchContent_Declare(
 )
 
 FetchContent_Declare(jl777-coins
-        URL https://github.com/KomodoPlatform/coins/archive/master.zip)
+        URL https://github.com/KomodoPlatform/coins/archive/ssl-only-coins-config.zip)
 
 #FetchContent_Declare(adex-generics-coins
 #        URL https://github.com/KomodoPlatform/komodo-wallet-desktop/archive/main.zip)

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -119,14 +119,13 @@ QtObject {
 
     function zhtlcActivationProgress(activation_status, coin='ARRR')
     {
-        
-        const coin_info = API.app.portfolio_pg.global_cfg_mdl.get_coin_info(coin)
-        let block_offset = coin_info.checkpoint_block
         let progress = 100
         if (!activation_status.hasOwnProperty("result")) return progress
-        // console.log("["+coin+"] [zhtlcActivationProgress]: " + JSON.stringify(activation_status))
+        const coin_info = API.app.portfolio_pg.global_cfg_mdl.get_coin_info(coin)
+        let block_offset = coin_info.checkpoint_height
         let status = activation_status.result.status
         let details = activation_status.result.details
+        // console.log("["+coin+"] [zhtlcActivationProgress]: " + JSON.stringify(activation_status))
 
         // use range from checkpoint block to present
         if (!status)
@@ -145,14 +144,14 @@ QtObject {
                 block_offset = details.UpdatingBlocksCache.first_sync_block.actual
                 let n = details.UpdatingBlocksCache.current_scanned_block - block_offset
                 let d = details.UpdatingBlocksCache.latest_block - block_offset
-                progress = 5 + parseInt(n/d*40)
+                progress = 5 + parseInt(n/d*20)
             }
             else if (details.hasOwnProperty("BuildingWalletDb"))
             {
                 block_offset = details.BuildingWalletDb.first_sync_block.actual
                 let n = details.BuildingWalletDb.current_scanned_block - block_offset
                 let d = details.BuildingWalletDb.latest_block - block_offset
-                progress = 45 + parseInt(n/d*40)
+                progress = 45 + parseInt(n/d*60)
             }
             else if (details.hasOwnProperty("RequestingBalance")) progress = 95
             else if (details.hasOwnProperty("ActivatingCoin")) progress = 5

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -125,8 +125,6 @@ QtObject {
         let block_offset = coin_info.checkpoint_height
         let status = activation_status.result.status
         let details = activation_status.result.details
-        // console.log("["+coin+"] [zhtlcActivationProgress]: " + JSON.stringify(activation_status))
-
         // use range from checkpoint block to present
         if (!status)
         {
@@ -152,12 +150,14 @@ QtObject {
                 let n = details.BuildingWalletDb.current_scanned_block - block_offset
                 let d = details.BuildingWalletDb.latest_block - block_offset
                 progress = 45 + parseInt(n/d*60)
+                if progress > 95: progress = 95
             }
             else if (details.hasOwnProperty("RequestingBalance")) progress = 95
             else if (details.hasOwnProperty("ActivatingCoin")) progress = 5
             else progress = 5
         }
         else console.log("["+coin+"] [zhtlcActivationProgress] Unexpected status: " + status)
+        if progress > 100: progress = 98
         return progress
     }
 

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -150,14 +150,20 @@ QtObject {
                 let n = details.BuildingWalletDb.current_scanned_block - block_offset
                 let d = details.BuildingWalletDb.latest_block - block_offset
                 progress = 45 + parseInt(n/d*60)
-                if progress > 95: progress = 95
+                if (progress > 95) {
+                    progress = 95
+                }
+                
             }
             else if (details.hasOwnProperty("RequestingBalance")) progress = 95
             else if (details.hasOwnProperty("ActivatingCoin")) progress = 5
             else progress = 5
         }
         else console.log("["+coin+"] [zhtlcActivationProgress] Unexpected status: " + status)
-        if progress > 100: progress = 98
+        if (progress > 100) {
+            progress = 98
+        }
+        
         return progress
     }
 

--- a/atomic_defi_design/Dex/Exchange/ProView/DexComboBoxLine.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/DexComboBoxLine.qml
@@ -40,7 +40,7 @@ RowLayout
             anchors.centerIn: parent
             anchors.fill: parent
             radius: 10
-            enabled: Dex.General.isZhtlc(details.ticker) ? activation_progress != 100 : false
+            enabled: Dex.General.isZhtlc(details.ticker) ? activation_progress < 100 : false
             visible: enabled
             opacity: .9
             color: Dex.DexTheme.backgroundColor
@@ -50,7 +50,7 @@ RowLayout
         {
             anchors.centerIn: parent
             anchors.fill: parent
-            enabled: Dex.General.isZhtlc(details.ticker) ? activation_progress != 100 : false
+            enabled: Dex.General.isZhtlc(details.ticker) ? activation_progress < 100 : false
             visible: enabled
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter

--- a/atomic_defi_design/Dex/Portfolio/AssetsList.qml
+++ b/atomic_defi_design/Dex/Portfolio/AssetsList.qml
@@ -126,7 +126,7 @@ Dex.DexListView
                         anchors.centerIn: parent
                         anchors.fill: parent
                         radius: 15
-                        enabled: Dex.General.isZhtlc(ticker) ? activation_progress != 100 : false
+                        enabled: Dex.General.isZhtlc(ticker) ? activation_progress < 100 : false
                         visible: enabled
                         opacity: .9
                         color: Dex.DexTheme.backgroundColor
@@ -136,7 +136,7 @@ Dex.DexListView
                     {
                         anchors.centerIn: parent
                         anchors.fill: parent
-                        enabled: Dex.General.isZhtlc(ticker) ? activation_progress != 100 : false
+                        enabled: Dex.General.isZhtlc(ticker) ? activation_progress < 100 : false
                         visible: enabled
                         horizontalAlignment: Text.AlignHCenter
                         verticalAlignment: Text.AlignVCenter

--- a/atomic_defi_design/Dex/Wallet/SidebarItemDelegate.qml
+++ b/atomic_defi_design/Dex/Wallet/SidebarItemDelegate.qml
@@ -62,7 +62,7 @@ GradientRectangle
             anchors.centerIn: parent
             anchors.fill: parent
             radius: 15
-            enabled: Dex.General.isZhtlc(ticker) ? activation_progress != 100 : false
+            enabled: Dex.General.isZhtlc(ticker) ? activation_progress < 100 : false
             visible: enabled
             opacity: .9
             color: Dex.DexTheme.backgroundColor
@@ -72,7 +72,7 @@ GradientRectangle
         {
             anchors.centerIn: parent
             anchors.fill: parent
-            enabled: Dex.General.isZhtlc(ticker) ? activation_progress != 100 : false
+            enabled: Dex.General.isZhtlc(ticker) ? activation_progress < 100 : false
             visible: enabled
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter

--- a/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.cpp
+++ b/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.cpp
@@ -28,7 +28,7 @@ namespace atomic_dex::mm2
     {
         j["params"]["ticker"]                                                          = request.coin_name;
         j["params"]["activation_params"]["mode"]["rpc"]                                = "Light";
-        j["params"]["activation_params"]["mode"]["rpc_data"]["sync_params"]["date"]    = request.sync_date;
+        j["params"]["activation_params"]["mode"]["rpc_data"]["sync_params"]["height"]  = request.sync_height;
         j["params"]["activation_params"]["mode"]["rpc_data"]["electrum_servers"]       = request.servers;
         j["params"]["activation_params"]["mode"]["rpc_data"]["light_wallet_d_servers"] = request.z_urls;
         j["params"]["activation_params"]["scan_blocks_per_iteration"]                  = 5000;

--- a/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.hpp
+++ b/src/core/atomicdex/api/mm2/rpc2.task.enable_z_coin.init.hpp
@@ -34,7 +34,7 @@ namespace atomic_dex::mm2
         std::vector<atomic_dex::electrum_server>  servers;
         std::vector<std::string>                  z_urls;
         CoinType                                  coin_type;
-        int                                       sync_date{1672531200};   // Jan 1st 2023
+        int                                       sync_height{0};
         bool                                      is_testnet{false};
         bool                                      with_tx_history{false};  // Not yet in API
     };

--- a/src/core/atomicdex/config/coins.cfg.cpp
+++ b/src/core/atomicdex/config/coins.cfg.cpp
@@ -168,6 +168,8 @@ namespace atomic_dex
         cfg.wallet_only          = is_wallet_only(cfg.ticker) ? is_wallet_only(cfg.ticker) : j.contains("wallet_only") ? j.at("wallet_only").get<bool>() : false;
         cfg.default_coin         = is_default_coin(cfg.ticker);
         cfg.is_faucet_coin       = is_faucet_coin(cfg.ticker);
+        cfg.checkpoint_height    = 0;
+        cfg.checkpoint_blocktime = 0;
         using namespace std::chrono;
 
         if (j.contains("other_types"))
@@ -225,6 +227,14 @@ namespace atomic_dex
         if (j.contains("light_wallet_d_servers"))
         {
             cfg.z_urls = j.at("light_wallet_d_servers").get<std::vector<std::string>>();
+        }
+        if (j.contains("checkpoint_blocktime"))
+        {
+            cfg.checkpoint_blocktime = j.at("checkpoint_blocktime").get<int>();
+        }
+        if (j.contains("checkpoint_height"))
+        {
+            cfg.checkpoint_height = j.at("checkpoint_height").get<int>();
         }
         if (j.contains("alias_ticker"))
         {

--- a/src/core/atomicdex/config/coins.cfg.hpp
+++ b/src/core/atomicdex/config/coins.cfg.hpp
@@ -55,6 +55,8 @@ namespace atomic_dex
         std::string                                       minimal_claim_amount{"0"};
         CoinType                                          coin_type;
         nlohmann::json                                    activation_status;
+        int                                               checkpoint_height{0};
+        int                                               checkpoint_blocktime{0};
         bool                                              segwit{false};
         bool                                              active{false};
         bool                                              checked{false};

--- a/src/core/atomicdex/models/qt.global.coins.cfg.model.cpp
+++ b/src/core/atomicdex/models/qt.global.coins.cfg.model.cpp
@@ -47,6 +47,8 @@ namespace
             {"is_erc_family", coin.is_erc_family},
             {"is_zhtlc_family", coin.is_zhtlc_family},
             {"is_wallet_only", coin.wallet_only},
+            {"checkpoint_height", coin.checkpoint_height},
+            {"checkpoint_blocktime", coin.checkpoint_blocktime},
             {"has_memos", coin.has_memos},
             {"fees_ticker", QString::fromStdString(coin.fees_ticker)}};
         return j;

--- a/src/core/atomicdex/pages/qt.settings.page.cpp
+++ b/src/core/atomicdex/pages/qt.settings.page.cpp
@@ -84,6 +84,29 @@ namespace atomic_dex
         QSettings& settings = entity_registry_.ctx<QSettings>();
         return settings.value("PirateSyncDate").toInt();
     }
+    int settings_page::get_pirate_sync_height(int sync_date, int checkpoint_height, int checkpoint_blocktime) const
+    {
+        if (checkpoint_height == 0)
+        {
+            return 0;
+        }
+        int blocktime_estimate = 65; // Based on average block time between checkpoint block and block 2575600 + margin of error
+        SPDLOG_INFO("sync_date: {}", sync_date);
+        SPDLOG_INFO("checkpoint_height: {}", checkpoint_height);
+        SPDLOG_INFO("checkpoint_blocktime: {}", checkpoint_blocktime);
+        int time_delta = sync_date - checkpoint_blocktime;
+        SPDLOG_INFO("time_delta: {}", time_delta);
+        int block_delta =  static_cast<int>(time_delta / blocktime_estimate);
+        SPDLOG_INFO("block_delta: {}", block_delta);
+        // As block time is variable, we round height to the nearest 1000 blocks
+        int height = checkpoint_height + static_cast<int>(block_delta / 1000) * 1000;
+        if (height < 0)
+        {
+            height = 0;
+        }
+        SPDLOG_INFO("height: {}", height);
+        return height;
+    }
 
     void settings_page::set_pirate_sync_date(int new_timestamp)
     {

--- a/src/core/atomicdex/pages/qt.settings.page.hpp
+++ b/src/core/atomicdex/pages/qt.settings.page.hpp
@@ -110,6 +110,7 @@ namespace atomic_dex
         Q_INVOKABLE [[nodiscard]] bool          is_this_ticker_present_in_normal_cfg(const QString& ticker) const;
         Q_INVOKABLE [[nodiscard]] QString       get_custom_coins_icons_path() const;
         Q_INVOKABLE [[nodiscard]] int           get_pirate_sync_date() const;
+        Q_INVOKABLE [[nodiscard]] int           get_pirate_sync_height(int sync_date, int checkpoint_height, int checkpoint_blocktime) const;
         Q_INVOKABLE void                        process_token_add(const QString& contract_address, const QString& coingecko_id, const QString& icon_filepath, CoinType coin_type);
         Q_INVOKABLE void                        process_qrc_20_token_add(const QString& contract_address, const QString& coingecko_id, const QString& icon_filepath);
         Q_INVOKABLE void                        submit();

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -1403,14 +1403,15 @@ namespace atomic_dex
         auto request_functor = [this](coin_config coin_info) -> std::pair<nlohmann::json, std::vector<std::string>>
         {
             const auto& settings_system  = m_system_manager.get_system<settings_page>();
-            int sync_from_date = settings_system.get_pirate_sync_date();
+            int sync_date = settings_system.get_pirate_sync_date();
+            int sync_height = settings_system.get_pirate_sync_height(sync_date, coin_info.checkpoint_height, coin_info.checkpoint_blocktime);
 
             t_enable_z_coin_request request{
                 .coin_name            = coin_info.ticker,
                 .servers              = coin_info.electrum_urls.value_or(get_electrum_server_from_token(coin_info.ticker)),
                 .z_urls               = coin_info.z_urls.value_or(std::vector<std::string>{}),
                 .coin_type            = coin_info.coin_type,
-                .sync_date            = sync_from_date,
+                .sync_height          = sync_height,
                 .is_testnet           = coin_info.is_testnet.value_or(false),
                 .with_tx_history      = false}; // Tx history not yet ready for ZHTLC
 


### PR DESCRIPTION
This PR is a further improvement on Z coin activation. Previously we used the "date" sync param, which would be effectively changed in the API to a derived height based on the average block time. 
As blocktime varies, this potentially resulted in the derived height not being a constant value, and in cases where it did not return the same height as calculated during a prior sync, could force a long resync.
The simplest mitigation for this was to use the height param in the RPC instead, derived by the GUI and rounding the height to the nearest 1000 so that the same date selection would be much more likely to return the same value as in the past.

To Test:
- Use the debug build of the app from CI to see the relevant log entries
- Activate ARRR with a date set last month. Check the logs to find `"requested":2448000` value in logs on lines like below:

`[14:55:02] [info] [mm2.service.cpp:1495] [2605136]: ARRR Activation Status: {"id":null,"mmrpc":"2.0","result":{"details":{"UpdatingBlocksCache":{"current_scanned_block":2521275,"first_sync_block":{"actual":2448000,"is_pre_sapling":false,"requested":2448000},"latest_block":2575728}},"status":"InProgress"}}`

the `requested` value should be divisible by  1000.

- activate ARRR again, using same date. You should see the same value for `requested`. 

**Note: This relies on updated data in `coins_config.json`, so please delete your local `%appdata%/0.6.1` folder and the coins file used for your wallet before launch**