### PR TITLE
fix tendermint tx history

### DIFF
--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -1298,36 +1298,27 @@ namespace atomic_dex
             std::size_t     limit =  5000;
             bool            requires_v2 = false;
             std::string     method = "my_tx_history";
-            if (coin_info.coin_type == CoinTypeGadget::SLP || coin_info.ticker == "tBCH" || coin_info.ticker == "BCH")
+            if (coin_info.coin_type == CoinTypeGadget::ZHTLC || coin_info.coin_type == CoinTypeGadget::TENDERMINT || coin_info.coin_type == CoinTypeGadget::TENDERMINTTOKEN || coin_info.coin_type == CoinTypeGadget::SLP || coin_info.ticker == "tBCH" || coin_info.ticker == "BCH")
             {
                 requires_v2 = true;
-                t_tx_history_request request{.coin = ticker, .limit = limit};
-                nlohmann::json       j = mm2::template_request(method, requires_v2);
-                mm2::to_json(j, request);
-                batch_array.push_back(j);
-            }
-            else if (coin_info.is_zhtlc_family)
-            {
-                // Don't request balance / history if not completely activated.
-                if (coin_info.activation_status.at("result").at("status") == "Ok")
+                if (coin_info.is_zhtlc_family)
                 {
-                    limit = 50;
-                    requires_v2 = true;
-                    method = "z_coin_tx_history";
-                    t_tx_history_request request{.coin = ticker, .limit = limit};
-                    nlohmann::json       j = mm2::template_request(method, requires_v2);
-                    mm2::to_json(j, request);
-                    batch_array.push_back(j);
+                    // Don't request balance / history if not completely activated.
+                    if (coin_info.activation_status.at("result").at("status") == "Ok")
+                    {
+                        limit = 50;
+                        method = "z_coin_tx_history";
+                    }
+                    else
+                    {
+                        return std::make_tuple(batch_array, tickers_idx, tokens_to_fetch);
+                    }
                 }
             }
-            else
-            {
-                t_tx_history_request request{.coin = ticker, .limit = limit};
-                nlohmann::json       j = mm2::template_request(method, requires_v2);
-                mm2::to_json(j, request);
-                batch_array.push_back(j);
-            }
-
+            t_tx_history_request request{.coin = ticker, .limit = limit};
+            nlohmann::json       j = mm2::template_request(method, requires_v2);
+            mm2::to_json(j, request);
+            batch_array.push_back(j);
         }
 
         if (not only_tx)


### PR DESCRIPTION
closes https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2368

To test:
- Log in to wallet with recent ATOM transactions
- activate ATOM, and open it in wallet page
- tx history should be visible
- Check tx history for ZHTLC coins also to confirm no regression.

Note: due to node pruning, older transactions may not be visible.