### PR TITLE
Fix "Type" typo

### DIFF
--- a/atomic_defi_design/Dex/Support/SupportModal.qml
+++ b/atomic_defi_design/Dex/Support/SupportModal.qml
@@ -146,7 +146,7 @@ Network fees can vary greatly depending on your selected trading pair.").arg(API
                 FAQLine
                 {
                     title: qsTr("I see a transaction in my wallet that was marked as 'poison'. What does this mean?")
-                    text: qsTr('Address poisoning is a relatively new tye of phishing attack, where a malicious actor aims to trick you into sending funds to an address that you did not intend to send funds to.
+                    text: qsTr('Address poisoning is a relatively new type of phishing attack, where a malicious actor aims to trick you into sending funds to an address that you did not intend to send funds to.
 
 This is often done by sending a zero value transaction to your wallet from an address which looks very similar to your actual address, with the exact same letters at the start and end. This transaction will then appear in your transaction history, with the scammer hoping you will mistake the fake address for your own and send funds to it.
 


### PR DESCRIPTION
## Abstract

Simply fixes a typo:
> _[...] relatively new **tye** of phishing attack [...]_
_[...] relatively new **type** of phishing attack [...]_

On another note, should I also correct the translation files? Since [all of them contain the typo](https://github.com/search?q=repo%3AKomodoPlatform%2Fkomodo-wallet-desktop+tye+path%3A%2F%5Eatomic_defi_design%5C%2Fassets%5C%2Flanguages%5C%2F%2F&type=code), or do you folks have an automated process for translation files?