### PR TITLE
Show trade volume for pair under pro orderbook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,13 +60,13 @@ endif ()
 ##! We fetch our dependencies
 if (APPLE)
     FetchContent_Declare(mm2
-            URL https://sdk.devbuilds.komodo.earth/dev/mm2_a9f606d-mac-x86-64.zip)
+            URL https://sdk.devbuilds.komodo.earth/main/mm2_79f6205-mac-x86-64.zip)
 elseif (UNIX AND NOT APPLE)
     FetchContent_Declare(mm2
-            URL https://sdk.devbuilds.komodo.earth/dev/mm2_a9f606d-linux-x86-64.zip)
+            URL https://sdk.devbuilds.komodo.earth/main/mm2_79f6205-linux-x86-64.zip)
 else ()
     FetchContent_Declare(mm2
-            URL https://sdk.devbuilds.komodo.earth/dev/mm2_a9f606d-win-x86-64.zip)
+            URL https://sdk.devbuilds.komodo.earth/main/mm2_79f6205-win-x86-64.zip)
 endif ()
 
 #FetchContent_Declare(qmaterial URL https://github.com/KomodoPlatform/Qaterial/archive/last-clang-working-2.zip)

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -546,7 +546,6 @@ QtObject {
         if (precision == 2 && fiat == "BTC") {
             precision = 8
         }
-        console.log("formatFiat", received, amount, fiat, precision)
         return diffPrefix(received) +
                 (fiat === API.app.settings_pg.current_fiat ? API.app.settings_pg.current_fiat_sign : API.app.settings_pg.current_currency_sign)
                 + " " + (amount < 1E5 ? formatDouble(parseFloat(amount), precision, true) : nFormatter(parseFloat(amount), 2))

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -542,6 +542,17 @@ QtObject {
       return (num / si[i].value).toFixed(digits).replace(rx, "$1") + si[i].symbol
     }
 
+    function convertUsd(v) {
+        let rate = API.app.get_rate_conversion("USD", API.app.settings_pg.current_currency)
+        let value = parseFloat(v) / parseFloat(rate)
+
+        if (API.app.settings_pg.current_fiat == API.app.settings_pg.current_currency) {
+            let fiat_rate = API.app.get_fiat_rate(API.app.settings_pg.current_fiat)
+            value = parseFloat(v) * parseFloat(fiat_rate)
+        }
+        return formatFiat("", value, API.app.settings_pg.current_currency)
+    }
+
     function formatFiat(received, amount, fiat, precision=2) {
         if (precision == 2 && fiat == "BTC") {
             precision = 8
@@ -740,8 +751,10 @@ QtObject {
     }
 
     function getFiatText(v, ticker, has_info_icon=true) {
-        return General.formatFiat('', v === '' ? 0 : API.app.get_fiat_from_amount(ticker, v), API.app.settings_pg.current_fiat)
-                + (has_info_icon ? " " +  General.cex_icon : "")
+        let fiat_from_amount = API.app.get_fiat_from_amount(ticker, v)
+        let current_fiat = API.app.settings_pg.current_fiat
+        let formatted_fiat = General.formatFiat('', v === '' ? 0 : fiat_from_amount, current_fiat)
+        return formatted_fiat + (has_info_icon ? " " +  General.cex_icon : "")
     }
 
     function hasParentCoinFees(trade_info) {

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -543,6 +543,10 @@ QtObject {
     }
 
     function formatFiat(received, amount, fiat, precision=2) {
+        if (precision == 2 && fiat == "BTC") {
+            precision = 8
+        }
+        console.log("formatFiat", received, amount, fiat, precision)
         return diffPrefix(received) +
                 (fiat === API.app.settings_pg.current_fiat ? API.app.settings_pg.current_fiat_sign : API.app.settings_pg.current_currency_sign)
                 + " " + (amount < 1E5 ? formatDouble(parseFloat(amount), precision, true) : nFormatter(parseFloat(amount), 2))

--- a/atomic_defi_design/Dex/Exchange/ProView/DexComboBoxLine.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/DexComboBoxLine.qml
@@ -98,7 +98,7 @@ RowLayout
                 id: bottom_line
 
                 property string fiat_value: !details ? "" :
-                            General.formatFiat("", details.main_currency_balance, API.app.settings_pg.current_fiat_sign)
+                            General.formatFiat("", details.main_currency_balance, API.app.settings_pg.current_currency)
                 text: fiat_value
                 Layout.fillWidth: true
                 elide: Text.ElideRight

--- a/atomic_defi_design/Dex/Exchange/Trade/OrderBook/Vertical.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/OrderBook/Vertical.qml
@@ -61,7 +61,7 @@ Widget
         Layout.bottomMargin: 2
         Layout.alignment: Qt.AlignHCenter
         color: Dex.CurrentTheme.foregroundColor2
-        text_value: pair + qsTr(" traded 24hrs: %1").arg("<b>" + General.getFiatText(pair_volume_24hr, "USD", false) + "</b>")
+        text_value: pair + qsTr(" traded 24hrs: %1").arg("<b>" + General.convertUsd(pair_volume_24hr) + "</b>")
         font.pixelSize: Style.textSizeSmall1
     }
 }

--- a/atomic_defi_design/Dex/Exchange/Trade/OrderBook/Vertical.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/OrderBook/Vertical.qml
@@ -12,9 +12,11 @@ import Dex.Themes 1.0 as Dex
 Widget
 {
     title: qsTr("Order Book")
+    readonly property string pair_volume_24hr: API.app.trading_pg.pair_volume_24hr
+    readonly property string pair: atomic_qt_utilities.retrieve_main_ticker(left_ticker) + "/" + atomic_qt_utilities.retrieve_main_ticker(right_ticker)
 
-    margins: 10
-    spacing: 10
+    margins: 8    
+    spacing: 2
 
     Header
     {
@@ -32,14 +34,15 @@ Widget
 
     Item
     {
-        Layout.preferredHeight: 4
+        Layout.preferredHeight: 1
         Layout.fillWidth: true
         Rectangle
         {
             width: parent.width
             height: parent.height
             anchors.horizontalCenter: parent.horizontalCenter
-            color: Dex.CurrentTheme.floatingBackgroundColor
+            color: Dex.CurrentTheme.backgroundColor
+            opacity: 0.5
         }
     }
 
@@ -48,5 +51,17 @@ Widget
         isAsk: false
         Layout.fillHeight: true
         Layout.fillWidth: true
+    }
+
+    DefaultText
+    {
+        id: volume_text
+        visible: parseFloat(pair_volume_24hr) > 0
+        Layout.topMargin: 2
+        Layout.bottomMargin: 2
+        Layout.alignment: Qt.AlignHCenter
+        color: Dex.CurrentTheme.foregroundColor2
+        text_value: pair + qsTr(" traded 24hrs: %1").arg("<b>" + General.getFiatText(pair_volume_24hr, "USD", false) + "</b>")
+        font.pixelSize: Style.textSizeSmall1
     }
 }

--- a/atomic_defi_design/Dex/Portfolio/AssetsList.qml
+++ b/atomic_defi_design/Dex/Portfolio/AssetsList.qml
@@ -248,7 +248,7 @@ Dex.DexListView
                 verticalAlignment: Text.AlignVCenter
 
                 text_value: Dex.General.formatFiat('', main_currency_price_for_one_unit,
-                                                   Dex.API.app.settings_pg.current_currency, 6)
+                                                   Dex.API.app.settings_pg.current_currency, 8)
             }
 
             Item // Price Provider

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -101,7 +101,7 @@ set(EXPECTED_ENABLE_TESTS OFF CACHE BOOL "Override option" FORCE)
 
 FetchContent_Declare(
         expected
-        URL https://github.com/Milerius/expected/archive/patch-1.zip
+        URL https://github.com/KomodoPlatform/expected/archive/patch-1.zip
 )
 
 FetchContent_Declare(

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -498,6 +498,7 @@ namespace atomic_dex
 
         system_manager_.create_system<wallet_page>(system_manager_, this);
         system_manager_.create_system<global_price_service>(system_manager_, settings_page_system.get_cfg());
+        system_manager_.create_system<global_defi_stats_service>(system_manager_);
         system_manager_.create_system<orderbook_scanner_service>(system_manager_);
         //system_manager_.create_system<coinpaprika_provider>(system_manager_);
         //system_manager_.create_system<coingecko_provider>(system_manager_);

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -686,6 +686,20 @@ namespace atomic_dex
 namespace atomic_dex
 {
     QString
+    application::get_rate_conversion(const QString& fiat, const QString& ticker, bool adjusted)
+    {
+        const auto&     price_service = system_manager_.get_system<global_price_service>();
+        return QString::fromStdString(price_service.get_rate_conversion(fiat.toStdString(), ticker.toStdString(), adjusted));
+    }
+
+    QString
+    application::get_fiat_rate(const QString& fiat)
+    {
+        const auto&     price_service = system_manager_.get_system<global_price_service>();
+        return QString::fromStdString(price_service.get_fiat_rates(fiat.toStdString()));
+    }
+
+    QString
     application::get_fiat_from_amount(const QString& ticker, const QString& amount)
     {
         std::error_code ec;

--- a/src/app/app.hpp
+++ b/src/app/app.hpp
@@ -166,7 +166,9 @@ namespace atomic_dex
         Q_INVOKABLE bool               disable_coins(const QStringList& coins);
         Q_INVOKABLE bool               disable_no_balance_coins();
         Q_INVOKABLE bool               has_coins_with_balance();
+        Q_INVOKABLE QString            get_fiat_rate(const QString& fiat);
         Q_INVOKABLE QString            get_fiat_from_amount(const QString& ticker, const QString& amount);
+        Q_INVOKABLE QString            get_rate_conversion(const QString& fiat, const QString& ticker, bool adjusted = false);
 
       signals:
         void walletMgrChanged();

--- a/src/app/app.hpp
+++ b/src/app/app.hpp
@@ -46,6 +46,7 @@
 #include "atomicdex/services/exporter/exporter.service.hpp"
 #include "atomicdex/services/internet/internet.checker.service.hpp"
 #include "atomicdex/services/mm2/mm2.service.hpp"
+#include "atomicdex/services/price/defi.stats.hpp"
 #include "atomicdex/services/price/global.provider.hpp"
 #include "atomicdex/services/update/update.checker.service.hpp"
 #include "atomicdex/services/update/zcash.params.service.hpp"

--- a/src/core/atomicdex/events/events.hpp
+++ b/src/core/atomicdex/events/events.hpp
@@ -24,14 +24,15 @@
 
 namespace atomic_dex
 {
-    using mm2_started           = entt::tag<"mm2_started"_hs>;
-    using post_login            = entt::tag<"post_login"_hs>;
-    using gui_enter_trading     = entt::tag<"gui_enter_trading"_hs>;
-    using gui_leave_trading     = entt::tag<"gui_leave_trading"_hs>;
-    using mm2_initialized       = entt::tag<"mm2_running_and_enabling"_hs>;
-    using default_coins_enabled = entt::tag<"default_coins_enabled"_hs>;
+    using mm2_started               = entt::tag<"mm2_started"_hs>;
+    using post_login                = entt::tag<"post_login"_hs>;
+    using gui_enter_trading         = entt::tag<"gui_enter_trading"_hs>;
+    using gui_leave_trading         = entt::tag<"gui_leave_trading"_hs>;
+    using mm2_initialized           = entt::tag<"mm2_running_and_enabling"_hs>;
+    using default_coins_enabled     = entt::tag<"default_coins_enabled"_hs>;
     using current_currency_changed  = entt::tag<"update_orders_and_swap_values"_hs>;
     using force_update_providers    = entt::tag<"force_update_providers"_hs>;
+    using force_update_defi_stats   = entt::tag<"force_update_defi_stats"_hs>;
     using download_started          = entt::tag<"download_started"_hs>;
     using download_complete         = entt::tag<"download_complete"_hs>;
     using download_failed           = entt::tag<"download_failed"_hs>;

--- a/src/core/atomicdex/pages/qt.portfolio.page.cpp
+++ b/src/core/atomicdex/pages/qt.portfolio.page.cpp
@@ -76,7 +76,7 @@ namespace atomic_dex
     void
     portfolio_page::on_update_portfolio_values_event(const update_portfolio_values& evt)
     {
-        SPDLOG_INFO("Updating portfolio values with model: {}", evt.with_update_model);
+        // SPDLOG_DEBUG("Updating portfolio values with model: {}", evt.with_update_model);
 
         bool res = true;
         if (evt.with_update_model)

--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -1374,8 +1374,8 @@ namespace atomic_dex
     {
         const auto& defi_stats_service  = m_system_manager.get_system<global_defi_stats_service>();
         const auto* market_selector     = get_market_pairs_mdl();
-        const auto& base                = market_selector->get_left_selected_coin().toStdString();
-        const auto& rel                 = market_selector->get_right_selected_coin().toStdString();
+        const auto& base                = utils::retrieve_main_ticker(market_selector->get_left_selected_coin().toStdString(), true);
+        const auto& rel                 = utils::retrieve_main_ticker(market_selector->get_right_selected_coin().toStdString(), true);
         QString vol                     = QString::fromStdString(defi_stats_service.get_volume_24h(base, rel));
 
         if (vol != m_pair_volume_24hr)

--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -1376,7 +1376,7 @@ namespace atomic_dex
         const auto* market_selector     = get_market_pairs_mdl();
         const auto& base                = utils::retrieve_main_ticker(market_selector->get_left_selected_coin().toStdString(), true);
         const auto& rel                 = utils::retrieve_main_ticker(market_selector->get_right_selected_coin().toStdString(), true);
-        QString vol                     = QString::fromStdString(defi_stats_service.get_volume_24h(base, rel));
+        QString vol                     = QString::fromStdString(defi_stats_service.get_volume_24h_usd(base, rel));
 
         if (vol != m_pair_volume_24hr)
         {

--- a/src/core/atomicdex/pages/qt.trading.page.hpp
+++ b/src/core/atomicdex/pages/qt.trading.page.hpp
@@ -58,6 +58,7 @@ namespace atomic_dex
         Q_PROPERTY(QVariantMap preffered_order READ get_preferred_order WRITE set_preferred_order NOTIFY prefferedOrderChanged)
         Q_PROPERTY(SelectedOrderStatus selected_order_status READ get_selected_order_status WRITE set_selected_order_status NOTIFY selectedOrderStatusChanged)
         Q_PROPERTY(QString price_reversed READ get_price_reversed NOTIFY priceReversedChanged)
+        Q_PROPERTY(QString pair_volume_24hr READ get_pair_volume_24hr NOTIFY pairVolume24hrChanged)
         Q_PROPERTY(QString cex_price READ get_cex_price NOTIFY cexPriceChanged)
         Q_PROPERTY(QString cex_price_reversed READ get_cex_price_reversed NOTIFY cexPriceReversedChanged)
         Q_PROPERTY(QString cex_price_diff READ get_cex_price_diff NOTIFY cexPriceDiffChanged)
@@ -113,6 +114,7 @@ namespace atomic_dex
         QString                                m_max_volume{"0"};
         QString                                m_total_amount{"0.00777"};
         QString                                m_cex_price{"0"};
+        QString                                m_pair_volume_24hr{"0"};
         QString                                m_minimal_trading_amount{"0.0001"};
         std::optional<nlohmann::json>          m_preferred_order;
         boost::synchronized_value<QVariantMap> m_fees;
@@ -122,11 +124,12 @@ namespace atomic_dex
         void                       determine_max_volume();
         void                       determine_total_amount();
         void                       determine_cex_rates();
+        void                       determine_pair_volume_24hr();
         void                       cap_volume();
         [[nodiscard]] t_float_50   get_max_balance_without_dust(const std::optional<QString>& trade_with = std::nullopt) const;
         [[nodiscard]] TradingError generate_fees_error(QVariantMap fees) const;
         void                       set_preferred_settings();
-        static QString                    calculate_total_amount(QString price, QString volume) ;
+        static QString             calculate_total_amount(QString price, QString volume) ;
 
       public:
         //! Constructor
@@ -194,6 +197,7 @@ namespace atomic_dex
         void                          set_total_amount(QString total_amount);
         [[nodiscard]] QString         get_base_amount() const;
         [[nodiscard]] QString         get_rel_amount() const;
+        [[nodiscard]] QString         get_pair_volume_24hr() const;
         [[nodiscard]] QString         get_cex_price() const;
         [[nodiscard]] QString         get_cex_price_reversed() const;
         [[nodiscard]] QString         get_cex_price_diff() const;
@@ -234,6 +238,7 @@ namespace atomic_dex
         void baseAmountChanged();
         void relAmountChanged();
         void feesChanged();
+        void pairVolume24hrChanged();
         void cexPriceChanged();
         void cexPriceReversedChanged();
         void cexPriceDiffChanged();

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -1743,7 +1743,7 @@ namespace atomic_dex
 
     nlohmann::json mm2_service::prepare_batch_orderbook(bool is_a_reset)
     {
-        SPDLOG_INFO("[prepare_batch_orderbook] is_a_reset: {}", is_a_reset);
+        // SPDLOG_DEBUG("[prepare_batch_orderbook] is_a_reset: {}", is_a_reset);
         auto&& [base, rel] = m_synchronized_ticker_pair.get();
         if (rel.empty())
             return nlohmann::json::array();

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -1915,6 +1915,7 @@ namespace atomic_dex
         this->m_current_wallet_name = std::move(wallet_name);
         this->dispatcher_.trigger<coin_cfg_parsed>(this->retrieve_coins_informations());
         this->dispatcher_.trigger<force_update_providers>();
+        this->dispatcher_.trigger<force_update_defi_stats>();
         mm2_config cfg{.passphrase = std::move(passphrase), .rpc_password = atomic_dex::gen_random_password()};
         mm2::set_system_manager(m_system_manager);
         mm2::set_rpc_password(cfg.rpc_password);

--- a/src/core/atomicdex/services/price/defi.stats.cpp
+++ b/src/core/atomicdex/services/price/defi.stats.cpp
@@ -131,8 +131,9 @@ namespace atomic_dex
     std::string
     global_defi_stats_service::get_volume_24h(const std::string& base, const std::string& quote) const
     {
-        std::string volume_24h = "0";
+        std::string volume_24h = "0.00";
         auto ticker = base + "_" + quote;
+        auto ticker_reversed = quote + "_" + base;
         SPDLOG_INFO("Getting 24hr volume data for {}", ticker);
         if (base == quote)
         {
@@ -150,6 +151,11 @@ namespace atomic_dex
             {
                 volume_24h = defi_ticker_stats.at("data").at(ticker).at("volume_usd_24hr").get<std::string>();
                 SPDLOG_INFO("{} volume usd: {}", ticker, volume_24h);
+            }
+            else if (defi_ticker_stats.at("data").contains(ticker_reversed))
+            {
+                volume_24h = defi_ticker_stats.at("data").at(ticker_reversed).at("volume_usd_24hr").get<std::string>();
+                SPDLOG_INFO("{} volume usd: {}", ticker_reversed, volume_24h);
             }
         }
         else

--- a/src/core/atomicdex/services/price/defi.stats.cpp
+++ b/src/core/atomicdex/services/price/defi.stats.cpp
@@ -19,6 +19,7 @@
 #include "atomicdex/services/price/komodo_prices/komodo.prices.provider.hpp"
 #include "atomicdex/api/coinpaprika/coinpaprika.hpp"
 #include "atomicdex/pages/qt.settings.page.hpp"
+#include "atomicdex/services/price/global.provider.hpp"
 
 
 //! Constructor
@@ -129,16 +130,16 @@ namespace atomic_dex
     }
 
     std::string
-    global_defi_stats_service::get_volume_24h(const std::string& base, const std::string& quote) const
+    global_defi_stats_service::get_volume_24h_usd(const std::string& base, const std::string& quote) const
     {
-        std::string volume_24h = "0.00";
+        std::string volume_24h_usd = "0.00";
         auto ticker = base + "_" + quote;
         auto ticker_reversed = quote + "_" + base;
         SPDLOG_INFO("Getting 24hr volume data for {}", ticker);
         if (base == quote)
         {
             SPDLOG_INFO("Base/quote must be different, no volume data for {}", ticker);
-            return volume_24h;
+            return volume_24h_usd;
         }
 
         auto defi_ticker_stats = m_defi_ticker_stats.get();
@@ -149,19 +150,19 @@ namespace atomic_dex
             SPDLOG_INFO("Combined volume usd: {}", defi_ticker_stats["combined_volume_usd"]);
             if (defi_ticker_stats.at("data").contains(ticker))
             {
-                volume_24h = defi_ticker_stats.at("data").at(ticker).at("volume_usd_24hr").get<std::string>();
-                SPDLOG_INFO("{} volume usd: {}", ticker, volume_24h);
+                volume_24h_usd = defi_ticker_stats.at("data").at(ticker).at("volume_usd_24hr").get<std::string>();
+                SPDLOG_INFO("{} volume usd: {}", ticker, volume_24h_usd);
             }
             else if (defi_ticker_stats.at("data").contains(ticker_reversed))
             {
-                volume_24h = defi_ticker_stats.at("data").at(ticker_reversed).at("volume_usd_24hr").get<std::string>();
-                SPDLOG_INFO("{} volume usd: {}", ticker_reversed, volume_24h);
+                volume_24h_usd = defi_ticker_stats.at("data").at(ticker_reversed).at("volume_usd_24hr").get<std::string>();
+                SPDLOG_INFO("{} volume usd: {}", ticker_reversed, volume_24h_usd);
             }
         }
         else
         {
             SPDLOG_WARN("Empty 24hr volume data for {}", defi_ticker_stats.dump(4));
         }
-        return volume_24h;
+        return volume_24h_usd;
     }
 } // namespace atomic_dex

--- a/src/core/atomicdex/services/price/defi.stats.cpp
+++ b/src/core/atomicdex/services/price/defi.stats.cpp
@@ -1,0 +1,161 @@
+/******************************************************************************
+ * Copyright © 2013-2023 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+//! Project Headers
+#include "atomicdex/services/price/defi.stats.hpp"
+#include "atomicdex/services/price/komodo_prices/komodo.prices.provider.hpp"
+#include "atomicdex/api/coinpaprika/coinpaprika.hpp"
+#include "atomicdex/pages/qt.settings.page.hpp"
+
+
+//! Constructor
+namespace atomic_dex
+{
+    global_defi_stats_service::global_defi_stats_service(entt::registry& registry, ag::ecs::system_manager& system_manager):
+        system(registry), m_system_manager(system_manager)
+    {
+        SPDLOG_INFO("global_defi_stats_service created");
+        m_update_clock = std::chrono::high_resolution_clock::now();
+        process_update();
+    }
+} // namespace atomic_dex
+
+namespace
+{
+    web::http::client::http_client_config g_defi_stats_cfg{
+        [](){
+            web::http::client::http_client_config cfg;
+            cfg.set_validate_certificates(false);
+            cfg.set_timeout(std::chrono::seconds(5));
+            return cfg;
+        }()
+    };
+
+    t_http_client_ptr g_defi_stats_client = std::make_unique<web::http::client::http_client>(FROM_STD_STR("https://defi-stats.komodo.earth/"), g_defi_stats_cfg);
+    pplx::cancellation_token_source d_token_source;
+
+    pplx::task<web::http::http_response>
+    async_fetch_defi_ticker_stats()
+    {
+        web::http::http_request req;
+        req.set_method(web::http::methods::GET);
+        req.set_request_uri(FROM_STD_STR("api/v3/tickers/summary"));
+        SPDLOG_INFO("defi_stats req: {}", TO_STD_STR(req.to_string()));
+        return g_defi_stats_client->request(req, d_token_source.get_token());
+    }
+
+    nlohmann::json
+    process_fetch_defi_ticker_stats_answer(web::http::http_response resp)
+    {
+        std::string body = TO_STD_STR(resp.extract_string(true).get());
+        if (resp.status_code() == 200)
+        {
+            nlohmann::json    answer = nlohmann::json::parse(body);
+            return answer;
+        }
+        else
+        {
+            SPDLOG_WARN("Failed to update defi_stats!");
+            return nlohmann::json::array();            
+        }
+        
+    }
+} // namespace
+
+namespace atomic_dex
+{
+    void
+    global_defi_stats_service::update()
+    {
+        using namespace std::chrono_literals;
+
+        const auto now = std::chrono::high_resolution_clock::now();
+        const auto s   = std::chrono::duration_cast<std::chrono::seconds>(now - m_update_clock);
+        if (s >= 5min)
+        {
+            SPDLOG_INFO("[global_defi_stats_service::update()] - 5min elapsed, updating ticker stats");
+            process_update();
+            m_update_clock = std::chrono::high_resolution_clock::now();
+        }
+    }
+
+} // namespace atomic_dex
+
+
+// Events
+namespace atomic_dex
+{   
+    void
+    global_defi_stats_service::process_update()
+    {
+        static std::atomic_size_t nb_try = 0;
+        nb_try += 1;
+        SPDLOG_INFO("pair volume stats service tick loop");
+        auto error_functor = [this](pplx::task<void> previous_task)
+        {
+            try
+            {
+                previous_task.wait();
+            }
+            catch (const std::exception& e)
+            {
+                SPDLOG_ERROR("pplx task error from async_fetch_ticker_stats: {} - nb_try {}", e.what(), nb_try);
+                using namespace std::chrono_literals;
+                std::this_thread::sleep_for(1s);
+                this->process_update();
+            };
+        };
+        async_fetch_defi_ticker_stats()
+            .then(
+                [this](web::http::http_response resp)
+                {
+                    this->m_defi_ticker_stats = process_fetch_defi_ticker_stats_answer(resp);
+                    nb_try = 0;
+                })
+            .then(error_functor);
+    }
+
+    std::string
+    global_defi_stats_service::get_volume_24h(const std::string& base, const std::string& quote) const
+    {
+        std::string volume_24h = "0";
+        auto ticker = base + "_" + quote;
+        SPDLOG_INFO("Getting 24hr volume data for {}", ticker);
+        if (base == quote)
+        {
+            SPDLOG_INFO("Base/quote must be different, no volume data for {}", ticker);
+            return volume_24h;
+        }
+
+        auto defi_ticker_stats = m_defi_ticker_stats.get();
+        // SPDLOG_INFO("Volume data: {}", defi_ticker_stats.dump(4));
+        
+        if (defi_ticker_stats.contains("data"))
+        {
+            SPDLOG_INFO("Combined volume usd: {}", defi_ticker_stats["combined_volume_usd"]);
+            if (defi_ticker_stats.at("data").contains(ticker))
+            {
+                volume_24h = defi_ticker_stats.at("data").at(ticker).at("volume_usd_24hr").get<std::string>();
+                SPDLOG_INFO("{} volume usd: {}", ticker, volume_24h);
+            }
+        }
+        else
+        {
+            SPDLOG_WARN("Empty 24hr volume data for {}", defi_ticker_stats.dump(4));
+        }
+        return volume_24h;
+    }
+} // namespace atomic_dex

--- a/src/core/atomicdex/services/price/defi.stats.hpp
+++ b/src/core/atomicdex/services/price/defi.stats.hpp
@@ -67,7 +67,7 @@ namespace atomic_dex
 
         //! Public API
         void                  process_defi_stats();
-        std::string           get_volume_24h(const std::string& base, const std::string& quote) const;
+        std::string           get_volume_24h_usd(const std::string& base, const std::string& quote) const;
 
         
         

--- a/src/core/atomicdex/services/price/defi.stats.hpp
+++ b/src/core/atomicdex/services/price/defi.stats.hpp
@@ -1,0 +1,77 @@
+/******************************************************************************
+ * Copyright © 2013-2021 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <antara/gaming/ecs/system.manager.hpp>
+#include <boost/thread/synchronized_value.hpp>
+#include <nlohmann/json.hpp>
+#include "atomicdex/config/app.cfg.hpp"
+#include "atomicdex/services/mm2/mm2.service.hpp"
+
+namespace atomic_dex::mm2
+{
+    struct defi_ticker_stats_answer
+    {
+        nlohmann::json                 result;
+        int                            status_code;
+    };
+    void from_json(const nlohmann::json& j, defi_ticker_stats_answer& answer);
+} // namespace atomic_dex::mm2
+
+
+namespace atomic_dex
+{
+    using t_defi_ticker_stats_answer         = mm2::defi_ticker_stats_answer;
+} // namespace atomic_dex
+
+namespace atomic_dex
+{
+    class global_defi_stats_service final : public ag::ecs::pre_update_system<global_defi_stats_service>
+    {
+
+        //! Private typedefs
+        using t_defi_stats_time_point     = std::chrono::high_resolution_clock::time_point;
+        using t_json_synchronized         = boost::synchronized_value<nlohmann::json>;
+
+        //! Private member fields
+        ag::ecs::system_manager&          m_system_manager;
+        t_json_synchronized               m_defi_ticker_stats;
+        t_defi_stats_time_point           m_update_clock;
+
+        //! private functions
+        void                              process_update();
+
+      public:
+        //! Constructor
+        explicit global_defi_stats_service(entt::registry& registry, ag::ecs::system_manager& system_manager);
+
+        //! Destructor
+        ~global_defi_stats_service()  final = default;
+
+        //! Public override
+        void update()  final;
+
+        //! Public API
+        void                  process_defi_stats();
+        std::string           get_volume_24h(const std::string& base, const std::string& quote) const;
+
+        
+        
+    };
+} // namespace atomic_dex
+
+REFL_AUTO(type(atomic_dex::global_defi_stats_service))

--- a/src/core/atomicdex/services/price/global.provider.cpp
+++ b/src/core/atomicdex/services/price/global.provider.cpp
@@ -463,11 +463,16 @@ namespace atomic_dex
     std::string
     global_price_service::get_fiat_rates(const std::string& fiat) const
     {
-        if (fiat == "USD")
+        if (is_fiat_available(fiat))
         {
-            return "1";
+           
+            if (fiat == "USD")
+            {
+                return "1";
+            }
+            return std::to_string(m_other_fiats_rates->at("rates").at(fiat).get<double>());
         }
-        return std::to_string(m_other_fiats_rates->at("rates").at(fiat).get<double>());
+        return "0";
     }
 
     bool
@@ -478,6 +483,20 @@ namespace atomic_dex
         auto rates = m_other_fiats_rates.get();
         // SPDLOG_INFO("rates: {}", rates.dump(4));
         return !rates.empty() && rates.contains("rates") && rates.at("rates").contains(fiat);
+    }
+
+    std::string
+    global_price_service::get_currency_rates(const std::string& currency) const
+    {
+        if (is_currency_available(currency))
+        {           
+            if (currency == "USD")
+            {
+                return "1";
+            }
+            return m_coin_rate_providers.at(currency);
+        }
+        return "0";
     }
 
     bool

--- a/src/core/atomicdex/services/price/global.provider.cpp
+++ b/src/core/atomicdex/services/price/global.provider.cpp
@@ -29,7 +29,7 @@ namespace
                                                               cfg.set_timeout(std::chrono::seconds(5));
                                                               return cfg;
                                                           }()};
-    t_http_client_ptr g_openrates_client = std::make_unique<web::http::client::http_client>(FROM_STD_STR("https://rates.komodo.earth"), g_openrates_cfg);
+    t_http_client_ptr g_openrates_client = std::make_unique<web::http::client::http_client>(FROM_STD_STR("https://defi-stats.komodo.earth"), g_openrates_cfg);
     pplx::cancellation_token_source g_token_source;
 
     pplx::task<web::http::http_response>
@@ -37,7 +37,7 @@ namespace
     {
         web::http::http_request req;
         req.set_method(web::http::methods::GET);
-        req.set_request_uri(FROM_STD_STR("api/v1/usd_rates"));
+        req.set_request_uri(FROM_STD_STR("api/v3/rates/fixer_io"));
         //SPDLOG_INFO("req: {}", TO_STD_STR(req.to_string()));
         return g_openrates_client->request(req, g_token_source.get_token());
     }

--- a/src/core/atomicdex/services/price/global.provider.hpp
+++ b/src/core/atomicdex/services/price/global.provider.hpp
@@ -58,6 +58,7 @@ namespace atomic_dex
         std::string get_price_as_currency_from_amount(const std::string& currency, const std::string& ticker, const std::string& amount) const ;
         std::string get_cex_rates(const std::string& base, const std::string& rel) const;
         std::string get_fiat_rates(const std::string& fiat) const;
+        std::string get_currency_rates(const std::string& currency) const;
 
         bool is_fiat_available(const std::string& fiat) const;
         bool is_currency_available(const std::string& currency) const;

--- a/src/core/atomicdex/utilities/global.utilities.cpp
+++ b/src/core/atomicdex/utilities/global.utilities.cpp
@@ -252,9 +252,18 @@ namespace atomic_dex::utils
     }
 
     std::string
-    retrieve_main_ticker(const std::string& ticker)
+    retrieve_main_ticker(const std::string& ticker, const bool segwit_only)
     {
-        if (const auto pos = ticker.find('-'); pos != std::string::npos)
+        auto pos = ticker.find('-');
+        if (segwit_only)
+        {
+            if (ticker.find('-segwit') != std::string::npos)
+            {
+                return ticker.substr(0, pos);
+            }
+            return ticker;
+        }
+        if (pos != std::string::npos)
         {
             return ticker.substr(0, pos);
         }

--- a/src/core/atomicdex/utilities/global.utilities.hpp
+++ b/src/core/atomicdex/utilities/global.utilities.hpp
@@ -94,7 +94,7 @@ namespace atomic_dex::utils
     ENTT_API std::filesystem::path get_themes_path();
     ENTT_API std::filesystem::path get_logo_path();
 
-    std::string retrieve_main_ticker(const std::string& ticker);
+    std::string retrieve_main_ticker(const std::string& ticker, const bool segwit_only = false);
 
     void to_eth_checksum(std::string& address);
 


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2382 and https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2384
![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/f464a197-c0bc-468d-8044-31ca5badfaf7)

To test:
- Confirm pairs match values at https://defi-stats.komodo.earth/api/v3/gecko/tickers
- Confirm reverse pair shows same values
- Confirm segwit / non-segwit pairs show same values
- If pair not in list on API, or zero volume traded, volume text should not display
- Confirm values update on fiat settings change as expected.
- Confirm pro view combo box text changes as expected when changing currency via menubar