### PR TITLE
Reduce high Tendermint fees

### DIFF
--- a/atomic_defi_design/Dex/Addressbook/AddAddressForm.qml
+++ b/atomic_defi_design/Dex/Addressbook/AddAddressForm.qml
@@ -31,6 +31,9 @@ Dex.Rectangle
             case "QRC-20":      return "QTUM"
             case "BEP-20":      return "BNB"
             case "ERC-20":      return "ETH"
+            case "AVX-20":      return "AVAX"
+            case "FTM-20":      return "FTM"
+            case "PLG-20":      return "MATIC"
             case "Smart Chain": return "KMD"
             case "SLP":         return "USDT-SLP"
         }
@@ -49,6 +52,9 @@ Dex.Rectangle
             case "QRC-20":      return true
             case "BEP-20":      return true
             case "ERC-20":      return true
+            case "PLG-20":      return true
+            case "AVX-20":      return true
+            case "FTM-20":      return true
             case "Smart Chain": return true
             case "SLP":         return true
         }

--- a/atomic_defi_design/Dex/Components/AmountFloatField.qml
+++ b/atomic_defi_design/Dex/Components/AmountFloatField.qml
@@ -1,0 +1,9 @@
+import QtQuick 2.15
+
+DefaultTextField
+{
+    validator: RegExpValidator
+    {
+        regExp: /([0-9]*[.])?[0-9]+/
+    }
+}

--- a/atomic_defi_design/Dex/Components/AmountIntField.qml
+++ b/atomic_defi_design/Dex/Components/AmountIntField.qml
@@ -2,8 +2,9 @@ import QtQuick 2.15
 
 DefaultTextField
 {
+    property bool allowFloat: false
     validator: RegExpValidator
     {
-        regExp: /[0-9]+/
+        regExp: allowFloat ? /([0-9]*[.])?[0-9]+/ : /[0-9]+/
     }
 }

--- a/atomic_defi_design/Dex/Constants/General.qml
+++ b/atomic_defi_design/Dex/Constants/General.qml
@@ -705,9 +705,13 @@ QtObject {
         return true
     }
 
-    function tokenUnitName(type)
+    function tokenUnitName(current_ticker_infos)
     {
-        return type === "QRC-20" ? "Satoshi" : "Gwei"
+        if (current_ticker_infos.type === "TENDERMINT" || current_ticker_infos.type === "TENDERMINTTOKEN")
+        {
+            return "u" + current_ticker_infos.name.toLowerCase()
+        }
+        return current_ticker_infos.type === "QRC-20" ? "Satoshi" : "Gwei"
     }
 
     function isSpecialToken(current_ticker_infos)

--- a/atomic_defi_design/Dex/Exchange/ProView/PlaceOrderForm/Main.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/PlaceOrderForm/Main.qml
@@ -258,6 +258,7 @@ Widget
             console.log("Getting fees info...")
             API.app.trading_pg.determine_fees()
             show_waiting_for_trade_preimage = true;
+            check_trade_preimage.start()
         }
 
         Item
@@ -275,20 +276,6 @@ Widget
                 anchors.centerIn: parent
                 indicatorSize: 32
                 indicatorDotSize: 5
-            }
-        }
-
-        DexMouseArea
-        {
-            id: areaAlert
-            hoverEnabled: true
-            anchors.fill: parent
-            onClicked: 
-            {
-                console.log("Getting fees info...")
-                API.app.trading_pg.determine_fees()
-                show_waiting_for_trade_preimage = true;
-                check_trade_preimage.start()
             }
         }
     }
@@ -315,7 +302,6 @@ Widget
                 errors.text_value = trade_preimage_error.toString()
                 show_waiting_for_trade_preimage = false
                 stop()
-
             }
             else if (loop_count > 50)
             {

--- a/atomic_defi_design/Dex/Exchange/ProView/PlaceOrderForm/OrderForm.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/PlaceOrderForm/OrderForm.qml
@@ -71,7 +71,10 @@ ColumnLayout
             height: 36
             radius: 18
 
-            onTextChanged: setPrice(text)
+            onTextChanged: {
+                setPrice(text)
+                reset_fees_state()
+            }
             Component.onCompleted: text = General.formatDouble(API.app.trading_pg.cex_price) ? General.formatDouble(API.app.trading_pg.cex_price) : 1
         }
 
@@ -87,17 +90,20 @@ ColumnLayout
                 let price = General.formatDouble(parseFloat(input_price.text) - (General.formatDouble(API.app.trading_pg.cex_price)*0.01))
                 if (price < 0) price = 0
                 setPrice(String(price))
+                reset_fees_state()
             }
             right_btn.onClicked:
             {
                 let price = General.formatDouble(parseFloat(input_price.text) + (General.formatDouble(API.app.trading_pg.cex_price)*0.01))
                 setPrice(String(price))
+                reset_fees_state()
             }
             middle_btn.onClicked:
             {
                 if (input_price.text == "0") setPrice("1")
                 let price = General.formatDouble(API.app.trading_pg.cex_price)
                 setPrice(String(price))
+                reset_fees_state()
             }
             fiat_value: General.getFiatText(non_null_price, right_ticker)
             left_label: "-1%"
@@ -124,7 +130,10 @@ ColumnLayout
             right_text: left_ticker
             placeholderText: "0" 
             text: API.app.trading_pg.volume
-            onTextChanged: setVolume(text)
+            onTextChanged: {
+                setVolume(text)
+                reset_fees_state()
+            }
         }
 
         OrderFormSubfield
@@ -137,16 +146,19 @@ ColumnLayout
             {
                 let volume = General.formatDouble(API.app.trading_pg.max_volume * 0.25)
                 setVolume(String(volume))
+                reset_fees_state()
             }
             middle_btn.onClicked:
             {
                 let volume = General.formatDouble(API.app.trading_pg.max_volume * 0.5)
                 setVolume(String(volume))
+                reset_fees_state()
             }
             right_btn.onClicked:
             {
                 let volume = General.formatDouble(API.app.trading_pg.max_volume)
                 setVolume(String(volume))
+                reset_fees_state()
             }
             fiat_value: General.getFiatText(non_null_volume, left_ticker)
             left_label: "25%"

--- a/atomic_defi_design/Dex/Exchange/Trade/Trade.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/Trade.qml
@@ -50,13 +50,15 @@ Item
     readonly property string backend_price: API.app.trading_pg.price
     function setPrice(v) {
         API.app.trading_pg.price = v
-         API.app.trading_pg.determine_error_cases()
+        reset_fees_state()
+        API.app.trading_pg.determine_error_cases()
     }
     readonly property int last_trading_error: API.app.trading_pg.last_trading_error
     readonly property string max_volume: API.app.trading_pg.max_volume
     readonly property string backend_volume: API.app.trading_pg.volume
     function setVolume(v) {
         API.app.trading_pg.volume = v
+        reset_fees_state()
         API.app.trading_pg.determine_error_cases()
     }
 

--- a/atomic_defi_design/Dex/Exchange/Trade/Trade.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/Trade.qml
@@ -50,12 +50,14 @@ Item
     readonly property string backend_price: API.app.trading_pg.price
     function setPrice(v) {
         API.app.trading_pg.price = v
+         API.app.trading_pg.determine_error_cases()
     }
     readonly property int last_trading_error: API.app.trading_pg.last_trading_error
     readonly property string max_volume: API.app.trading_pg.max_volume
     readonly property string backend_volume: API.app.trading_pg.volume
     function setVolume(v) {
         API.app.trading_pg.volume = v
+        API.app.trading_pg.determine_error_cases()
     }
 
     property bool sell_mode: API.app.trading_pg.market_mode.toString(

--- a/atomic_defi_design/Dex/Exchange/Trade/Trade.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/Trade.qml
@@ -50,7 +50,6 @@ Item
     readonly property string backend_price: API.app.trading_pg.price
     function setPrice(v) {
         API.app.trading_pg.price = v
-        reset_fees_state()
         API.app.trading_pg.determine_error_cases()
     }
     readonly property int last_trading_error: API.app.trading_pg.last_trading_error
@@ -58,7 +57,6 @@ Item
     readonly property string backend_volume: API.app.trading_pg.volume
     function setVolume(v) {
         API.app.trading_pg.volume = v
-        reset_fees_state()
         API.app.trading_pg.determine_error_cases()
     }
 

--- a/atomic_defi_design/Dex/Wallet/SendModal.qml
+++ b/atomic_defi_design/Dex/Wallet/SendModal.qml
@@ -683,13 +683,14 @@ MultipageModal
                 AmountIntField
                 {
                     id: input_custom_fees_gas_price
+                    allowFloat: current_ticker_infos.type === "TENDERMINT" ? true : "TENDERMINTTOKEN" ? true : false
 
                     enabled: !root.is_send_busy
 
                     Layout.preferredWidth: 380
                     Layout.preferredHeight: 38
 
-                    placeholderText: qsTr("Gas price") + " [" + General.tokenUnitName(current_ticker_infos.type) + "]"
+                    placeholderText: qsTr("Gas price") + " [" + General.tokenUnitName(current_ticker_infos) + "]"
                 }
             }
 

--- a/src/core/atomicdex/api/mm2/rpc2.withdraw.cpp
+++ b/src/core/atomicdex/api/mm2/rpc2.withdraw.cpp
@@ -6,6 +6,7 @@
 #include <nlohmann/json.hpp>
 
 //! Our Headers
+#include "atomicdex/utilities/global.utilities.hpp"
 #include "rpc2.withdraw.hpp"
 
 namespace atomic_dex::mm2
@@ -14,7 +15,7 @@ namespace atomic_dex::mm2
     to_json(nlohmann::json& j, const withdraw_fees& cfg)
     {
         j["type"] = cfg.type;
-        if (cfg.type == "EthGas")
+        if (cfg.type == "EthGas" || cfg.type == "otherGas")
         {
             j["gas"]       = cfg.gas_limit.value_or(55000);
             j["gas_price"] = cfg.gas_price.value();
@@ -24,11 +25,11 @@ namespace atomic_dex::mm2
             j["gas_limit"] = cfg.gas_limit.value_or(40);
             j["gas_price"] = std::stoi(cfg.gas_price.value());
         }
-        else if (cfg.type == "otherGas")
+        else if (cfg.type == "CosmosGas")
         {
-            j["type"] = "EthGas";
-            j["gas"]       = cfg.gas_limit.value_or(55000);
-            j["gas_price"] = std::stoi(cfg.gas_price.value());
+            j["type"] = "CosmosGas";
+            j["gas_limit"]       = cfg.gas_limit.value_or(55000);
+            j["gas_price"]       = cfg.cosmos_gas_price.value_or(0.03);
         }
         else
         {

--- a/src/core/atomicdex/api/mm2/rpc2.withdraw.hpp
+++ b/src/core/atomicdex/api/mm2/rpc2.withdraw.hpp
@@ -14,10 +14,11 @@ namespace atomic_dex::mm2
 {
     struct withdraw_fees
     {
-        std::string                type;      ///< UtxoFixed, UtxoPerKbyte, EthGas, Qrc20Gas
-        std::optional<std::string> amount;    ///< Utxo only
-        std::optional<std::string> gas_price; ///< price EthGas or Qrc20Gas
-        std::optional<int>         gas_limit; ///< sets the gas limit for transaction
+        std::string                  type;             ///< UtxoFixed, UtxoPerKbyte, EthGas, Qrc20Gas
+        std::optional<std::string>   amount;           ///< Utxo only
+        std::optional<std::string>   gas_price;        ///< price EthGas or Qrc20Gas
+        std::optional<std::double_t> cosmos_gas_price; ///< price CosmosGas or Qrc20Gas
+        std::optional<int>           gas_limit;        ///< sets the gas limit for transaction
     };
 
     void to_json(nlohmann::json& j, const withdraw_fees& cfg);


### PR DESCRIPTION
Solves https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2371 until an API level solution is available.
To Test:
- try sending Tendermint assets (ATOM, IRIS, OSMO, ATOM-IRIS_IBC) without custom fee.
- try sending Tendermint assets (ATOM, IRIS, OSMO, ATOM-IRIS_IBC) with custom fee.

IRIS seemed to be the first to reject the tx when static fee was reduced further. The following values should work for custom fees for all Tendermint coins:
- gas_price: 0.05
- gas_limit: 150000
