### PR TITLE
Filter out disabled coins in simple mode

### DIFF
--- a/atomic_defi_design/Dex/Components/SetupPage.qml
+++ b/atomic_defi_design/Dex/Components/SetupPage.qml
@@ -44,8 +44,8 @@ Item
 
             leftPadding: 30
             rightPadding: leftPadding
-            topPadding: leftPadding * 0.5
-            bottomPadding: topPadding
+            topPadding: 12
+            bottomPadding: 12
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
 
             background: DefaultRectangle
@@ -69,9 +69,9 @@ Item
 
     DexLanguage
     {
-        y: 52
+        y: 24
         anchors.right: parent.right
-        anchors.rightMargin: 52
+        anchors.rightMargin: 24
         width: 72
     }
 

--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/Main.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/Main.qml
@@ -36,7 +36,7 @@ Item
     Column
     {
         width: root.currentSubPage === subPages.Trade ? _simpleTrade.best ? 600 : 450 : 450
-        y: 80
+        y: 60
         spacing: 30
         anchors.horizontalCenter: parent.horizontalCenter
 

--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
@@ -125,9 +125,10 @@ DexListView
     delegate: DexRectangle // Order Line
     {
         property bool _isCoinEnabled: Constants.API.app.portfolio_pg.global_cfg_mdl.get_coin_info(coin).is_enabled
-
+        property bool _hideDisabled: hide_disabled_coins_checkbox.checked
+        visible: _isCoinEnabled ? true : _hideDisabled ? false : true
+        height: _isCoinEnabled ? _rowHeight : _hideDisabled ? 0 : _rowHeight
         width: _rowWidth
-        height: _rowHeight
         radius: mouse_area.containsMouse ? 3 : 0
         border.width: 0
         colorAnimation: false

--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/SubBestOrder.qml
@@ -177,6 +177,7 @@ DexListView
                     Layout.preferredWidth: _tokenColumnSize - parent._iconWidth
                     text_value: coin
                     font.pixelSize: 14
+                    opacity: !_isCoinEnabled? .3 : 1
                 }
             }
 
@@ -186,6 +187,7 @@ DexListView
                 horizontalAlignment: Text.AlignRight
                 text_value: parseFloat(General.formatDouble(rel_max_volume, General.amountPrecision, true)).toFixed(8)
                 font.pixelSize: 14
+                opacity: !_isCoinEnabled? .3 : 1
             }
 
             DexLabel                         // Order Available Quantity In BASE
@@ -194,6 +196,7 @@ DexListView
                 horizontalAlignment: Text.AlignRight
                 text_value: parseFloat(General.formatDouble(base_max_volume, General.amountPrecision, true)).toFixed(8)
                 font.pixelSize: 14
+                opacity: !_isCoinEnabled? .3 : 1
             }
 
             DexLabel                         // Order Fiat Volume
@@ -201,6 +204,7 @@ DexListView
                 Layout.preferredWidth: _fiatVolumeColumnSize
                 horizontalAlignment: Text.AlignRight
                 text_value: parseFloat(price_fiat).toFixed(2)+Constants.API.app.settings_pg.current_fiat_sign
+                opacity: !_isCoinEnabled? .3 : 1
             }
 
             DexLabel
@@ -209,6 +213,7 @@ DexListView
                 horizontalAlignment: Text.AlignRight
                 color: cex_rates=== "0" ? Qt.darker(DexTheme.foregroundColor) : parseFloat(cex_rates)>0? DexTheme.warningColor : DexTheme.okColor
                 text_value: cex_rates=== "0" ? "N/A" : parseFloat(cex_rates)>0? "+"+parseFloat(cex_rates).toFixed(2)+"%" : parseFloat(cex_rates).toFixed(2)+"%"
+                opacity: !_isCoinEnabled? .3 : 1
             }
 
             DexTooltip

--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/Trade.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/Trade.qml
@@ -37,7 +37,7 @@ ClipRRect // Trade Card
     onSelectedOrderChanged:
     {
         if (typeof selectedOrder !== 'undefined' && selectedOrder.from_best_order) Constants.API.app.trading_pg.orderbook.select_best_order(selectedOrder.uuid)
-        else if (typeof selectedOrder !== 'undefined') Constants.API.app.trading_pg.preferred_order = selectedOrder
+        else if (typeof selectedOrder !== 'undefined') Constants.API.app.trading_pg.preffered_order = selectedOrder
         else Constants.API.app.trading_pg.reset_order()
         Constants.API.app.trading_pg.determine_fees()
     }
@@ -735,7 +735,7 @@ ClipRRect // Trade Card
         Item
         {
             height: 35
-            width: 150
+            width: 206
             visible: coinSelectorSimplified.visible
 
             SearchField
@@ -747,6 +747,7 @@ ClipRRect // Trade Card
                 forceFocus: true
                 textField.onTextChanged: _coinList.model.setFilterFixedString(textField.text)
                 Component.onDestruction: _coinList.model.setFilterFixedString("")
+                textField.placeholderText: qsTr("Search coins")
             }
         }
 
@@ -782,21 +783,48 @@ ClipRRect // Trade Card
         Item
         {
             height: 45
-            width: 150
+            width: parent.width - 40
             visible: bestOrderSimplified.visible && (_bestOrderList.count > 0 || _bestOrderSearchField.textField.text != "")
-
-            SearchField
-            {
-                id: _bestOrderSearchField
-                anchors.topMargin: 10
-                height: 35
+    
+            RowLayout {
                 anchors.fill: parent
-                anchors.leftMargin: 20
-                forceFocus: true
-                textField.onTextChanged: Constants.API.app.trading_pg.orderbook.best_orders.proxy_mdl.setFilterFixedString(textField.text)
-                Component.onDestruction: Constants.API.app.trading_pg.orderbook.best_orders.proxy_mdl.setFilterFixedString("")
+
+                SearchField
+                {
+
+                    id: _bestOrderSearchField
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredWidth: 206
+                    Layout.preferredHeight: 35
+                    Layout.leftMargin: 20
+                    Layout.topMargin: 10
+                    forceFocus: true
+                    textField.onTextChanged: Constants.API.app.trading_pg.orderbook.best_orders.proxy_mdl.setFilterFixedString(textField.text)
+                    Component.onDestruction: Constants.API.app.trading_pg.orderbook.best_orders.proxy_mdl.setFilterFixedString("")
+                    textField.placeholderText: qsTr("Search coins")
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                DefaultCheckBox
+                {
+                    id: hide_disabled_coins_checkbox
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredHeight: 35
+                    Layout.topMargin: 10
+
+                    spacing: 2
+
+                    label.wrapMode: Label.NoWrap
+                    label.font.pixelSize: 14
+                    text: qsTr("Show only enabled coins")
+                    textColor: Dex.CurrentTheme.foregroundColor2
+                }
             }
         }
+        
 
         Item
         {

--- a/atomic_defi_design/Dex/Screens/Startup/Login.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/Login.qml
@@ -43,7 +43,7 @@ SetupPage
     content: ColumnLayout
     {
         id: content
-        spacing: 10
+        spacing: 8
 
         DexLabel
         {
@@ -51,12 +51,12 @@ SetupPage
             text: "%1 wallet".arg(walletName)
             color: Dex.CurrentTheme.foregroundColor
             font: DexTypo.body1
-            topPadding: 10
+            topPadding: 8
         }
 
         Item
         {
-            height: 20
+            height: 16
             width: 1
         }
 

--- a/atomic_defi_design/Dex/Screens/Startup/WalletsView.qml
+++ b/atomic_defi_design/Dex/Screens/Startup/WalletsView.qml
@@ -26,7 +26,7 @@ SetupPage
     signal walletSelected(string walletName);
 
     image_path: Dex.CurrentTheme.bigLogoPath
-    image_margin: 15
+    image_margin: 12
 
     backgroundColor: Dex.CurrentTheme.backgroundColor
 
@@ -34,7 +34,7 @@ SetupPage
     {
         id: content_column
         width: 270
-        spacing: Style.rowSpacing
+        spacing: 8
         RowLayout
         {
             Layout.fillWidth: true
@@ -115,7 +115,7 @@ SetupPage
 
                 width: content_column.width
                 Layout.minimumHeight: row_height
-                Layout.preferredHeight: (row_height * Math.min(wallet_count, 5)) + 20
+                Layout.preferredHeight: (row_height * Math.min(wallet_count, 4)) + 20
                 color: Dex.CurrentTheme.floatingBackgroundColor
                 radius: 18
 
@@ -294,10 +294,8 @@ SetupPage
     {
         Layout.alignment: Qt.AlignHCenter
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: 20
-
+        anchors.bottomMargin: 0
         anchors.horizontalCenter: parent.horizontalCenter
-
     }
 
     GaussianBlur


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2357

To test:
- Go to simple mode, select a sell coin and price.
- click to open the buy coin selection screen. 
- See disabled coins row faded
- use checkbox to hide disabled coins