### PR TITLE
fix symbol/text usage for selected fiat in send form

### DIFF
--- a/atomic_defi_design/Dex/Wallet/SendModal.qml
+++ b/atomic_defi_design/Dex/Wallet/SendModal.qml
@@ -509,7 +509,7 @@ MultipageModal
                     {
                         id: fiat_symbol
                         visible: _preparePage.cryptoSendMode && API.app.settings_pg.current_currency_sign != "KMD"
-                        font.pixelSize: 18
+                        font.pixelSize: API.app.settings_pg.current_currency_sign.length == 1 ? 18 : 18 - API.app.settings_pg.current_currency_sign.length * 2
                         anchors.centerIn: parent
                         text: API.app.settings_pg.current_currency_sign
                     }
@@ -520,7 +520,7 @@ MultipageModal
                         anchors.centerIn: parent
                         width: 18
                         height: 18
-                        source: General.coinIcon(API.app.wallet_pg.ticker)
+                        source: _preparePage.cryptoSendMode ? General.coinIcon(API.app.settings_pg.current_currency_sign) : General.coinIcon(API.app.wallet_pg.ticker)
                     }
                 }
 


### PR DESCRIPTION
I noticed a bug with the piratedex fork where if the selected fiat was `ARRR` it would overflow a button in the send form.

Before:

https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/4aca39c6-d25b-45e2-9e74-c69f9fea39ae



After:

https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/83dd7c20-cdbf-4c9b-8810-ed58458637ff

This repo does not offer ARRR as a fiat, but the same effect should be seen with fiat set to KMD.