### PR TITLE
add pair trades 24hr stat

### DIFF
--- a/atomic_defi_design/Dex/Exchange/Trade/OrderBook/Vertical.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/OrderBook/Vertical.qml
@@ -12,6 +12,7 @@ import Dex.Themes 1.0 as Dex
 Widget
 {
     title: qsTr("Order Book")
+    readonly property string pair_trades_24hr: API.app.trading_pg.pair_trades_24hr
     readonly property string pair_volume_24hr: API.app.trading_pg.pair_volume_24hr
     readonly property string pair: atomic_qt_utilities.retrieve_main_ticker(left_ticker) + "/" + atomic_qt_utilities.retrieve_main_ticker(right_ticker)
 
@@ -61,7 +62,7 @@ Widget
         Layout.bottomMargin: 2
         Layout.alignment: Qt.AlignHCenter
         color: Dex.CurrentTheme.foregroundColor2
-        text_value: pair + qsTr(" traded 24hrs: %1").arg("<b>" + General.convertUsd(pair_volume_24hr) + "</b>")
+        text_value: pair + qsTr(" 24hrs  |  %1  |  %2 trades").arg(General.convertUsd(pair_volume_24hr)).arg(pair_trades_24hr)
         font.pixelSize: Style.textSizeSmall1
     }
 }

--- a/src/core/atomicdex/pages/qt.trading.page.cpp
+++ b/src/core/atomicdex/pages/qt.trading.page.cpp
@@ -708,6 +708,7 @@ namespace atomic_dex
         this->m_preferred_order  = std::nullopt;
         this->m_fees             = QVariantMap();
         this->m_cex_price        = "0";
+        this->m_pair_trades_24hr = "0";
         this->m_pair_volume_24hr = "0";
         this->m_post_clear_forms = true;
         this->set_selected_order_status(SelectedOrderStatus::None);
@@ -1394,13 +1395,22 @@ namespace atomic_dex
         const auto* market_selector     = get_market_pairs_mdl();
         const auto& base                = utils::retrieve_main_ticker(market_selector->get_left_selected_coin().toStdString(), true);
         const auto& rel                 = utils::retrieve_main_ticker(market_selector->get_right_selected_coin().toStdString(), true);
+        QString trades                  = QString::fromStdString(defi_stats_service.get_trades_24h(base, rel));
         QString vol                     = QString::fromStdString(defi_stats_service.get_volume_24h_usd(base, rel));
 
         if (vol != m_pair_volume_24hr)
         {
+            m_pair_trades_24hr = trades;
+            emit pairTrades24hrChanged();
             m_pair_volume_24hr = vol;
             emit pairVolume24hrChanged();
         }        
+    }
+
+    QString
+    trading_page::get_pair_trades_24hr() const
+    {
+        return m_pair_trades_24hr;
     }
 
     QString

--- a/src/core/atomicdex/pages/qt.trading.page.hpp
+++ b/src/core/atomicdex/pages/qt.trading.page.hpp
@@ -59,6 +59,7 @@ namespace atomic_dex
         Q_PROPERTY(SelectedOrderStatus selected_order_status READ get_selected_order_status WRITE set_selected_order_status NOTIFY selectedOrderStatusChanged)
         Q_PROPERTY(QString price_reversed READ get_price_reversed NOTIFY priceReversedChanged)
         Q_PROPERTY(QString pair_volume_24hr READ get_pair_volume_24hr NOTIFY pairVolume24hrChanged)
+        Q_PROPERTY(QString pair_trades_24hr READ get_pair_trades_24hr NOTIFY pairTrades24hrChanged)
         Q_PROPERTY(QString cex_price READ get_cex_price NOTIFY cexPriceChanged)
         Q_PROPERTY(QString cex_price_reversed READ get_cex_price_reversed NOTIFY cexPriceReversedChanged)
         Q_PROPERTY(QString cex_price_diff READ get_cex_price_diff NOTIFY cexPriceDiffChanged)
@@ -115,6 +116,7 @@ namespace atomic_dex
         QString                                m_total_amount{"0.00777"};
         QString                                m_cex_price{"0"};
         QString                                m_pair_volume_24hr{"0"};
+        QString                                m_pair_trades_24hr{"0"};
         QString                                m_minimal_trading_amount{"0.0001"};
         std::optional<nlohmann::json>          m_preferred_order;
         boost::synchronized_value<QVariantMap> m_fees;
@@ -197,6 +199,7 @@ namespace atomic_dex
         void                          set_total_amount(QString total_amount);
         [[nodiscard]] QString         get_base_amount() const;
         [[nodiscard]] QString         get_rel_amount() const;
+        [[nodiscard]] QString         get_pair_trades_24hr() const;
         [[nodiscard]] QString         get_pair_volume_24hr() const;
         [[nodiscard]] QString         get_cex_price() const;
         [[nodiscard]] QString         get_cex_price_reversed() const;
@@ -238,6 +241,7 @@ namespace atomic_dex
         void baseAmountChanged();
         void relAmountChanged();
         void feesChanged();
+        void pairTrades24hrChanged();
         void pairVolume24hrChanged();
         void cexPriceChanged();
         void cexPriceReversedChanged();

--- a/src/core/atomicdex/services/price/defi.stats.cpp
+++ b/src/core/atomicdex/services/price/defi.stats.cpp
@@ -49,17 +49,17 @@ namespace
     pplx::cancellation_token_source d_token_source;
 
     pplx::task<web::http::http_response>
-    async_fetch_defi_ticker_stats()
+    async_fetch_defi_stats_volumes()
     {
         web::http::http_request req;
         req.set_method(web::http::methods::GET);
-        req.set_request_uri(FROM_STD_STR("api/v3/tickers/summary"));
+        req.set_request_uri(FROM_STD_STR("api/v3/pairs/volumes_24hr"));
         SPDLOG_INFO("defi_stats req: {}", TO_STD_STR(req.to_string()));
         return g_defi_stats_client->request(req, d_token_source.get_token());
     }
 
     nlohmann::json
-    process_fetch_defi_ticker_stats_answer(web::http::http_response resp)
+    process_fetch_defi_stats_volumes_answer(web::http::http_response resp)
     {
         std::string body = TO_STD_STR(resp.extract_string(true).get());
         if (resp.status_code() == 200)
@@ -119,11 +119,11 @@ namespace atomic_dex
                 this->process_update();
             };
         };
-        async_fetch_defi_ticker_stats()
+        async_fetch_defi_stats_volumes()
             .then(
                 [this](web::http::http_response resp)
                 {
-                    this->m_defi_ticker_stats = process_fetch_defi_ticker_stats_answer(resp);
+                    this->m_defi_stats_volumes = process_fetch_defi_stats_volumes_answer(resp);
                     nb_try = 0;
                 })
             .then(error_functor);
@@ -136,33 +136,140 @@ namespace atomic_dex
         auto ticker = base + "_" + quote;
         auto ticker_reversed = quote + "_" + base;
         SPDLOG_INFO("Getting 24hr volume data for {}", ticker);
+
+        // Check if base/quote are the same
         if (base == quote)
         {
             SPDLOG_INFO("Base/quote must be different, no volume data for {}", ticker);
             return volume_24h_usd;
         }
 
-        auto defi_ticker_stats = m_defi_ticker_stats.get();
-        // SPDLOG_INFO("Volume data: {}", defi_ticker_stats.dump(4));
-        
-        if (defi_ticker_stats.contains("data"))
+        // Check if defi_stats_volumes is valid
+        auto defi_stats_volumes = m_defi_stats_volumes.get();
+        if (!defi_stats_volumes.is_object())
         {
-            SPDLOG_INFO("Combined volume usd: {}", defi_ticker_stats["combined_volume_usd"]);
-            if (defi_ticker_stats.at("data").contains(ticker))
+            SPDLOG_WARN("Invalid defi stats volumes data.");
+            return volume_24h_usd;
+        }
+        
+        // Check if volumes key exists
+        if (!defi_stats_volumes.contains("volumes"))
+        {
+            SPDLOG_WARN("No volumes data available.");
+            return volume_24h_usd;
+        }
+
+        // Extract ticker trade_volume_usd safely
+        if (defi_stats_volumes.at("volumes").contains(ticker))
+        {
+            auto volume_node = defi_stats_volumes["volumes"][ticker]["ALL"]["trade_volume_usd"];
+            if (volume_node.is_number())
             {
-                volume_24h_usd = defi_ticker_stats.at("data").at(ticker).at("volume_usd_24hr").get<std::string>();
+                volume_24h_usd = std::to_string(volume_node.get<double>());
                 SPDLOG_INFO("{} volume usd: {}", ticker, volume_24h_usd);
             }
-            else if (defi_ticker_stats.at("data").contains(ticker_reversed))
+            else if (volume_node.is_null()) 
             {
-                volume_24h_usd = defi_ticker_stats.at("data").at(ticker_reversed).at("volume_usd_24hr").get<std::string>();
+                SPDLOG_WARN("Volume value is null for {}", ticker);
+            }
+            else
+            {
+                SPDLOG_WARN("Volume value is not a number for {}: {}", ticker, volume_node.type_name());
+            }
+        }
+        else if (defi_stats_volumes["volumes"].contains(ticker_reversed))
+        {
+            auto volume_node = defi_stats_volumes["volumes"][ticker_reversed]["ALL"]["trade_volume_usd"];
+            if (volume_node.is_number())
+            {
+                volume_24h_usd = std::to_string(volume_node.get<double>());
                 SPDLOG_INFO("{} volume usd: {}", ticker_reversed, volume_24h_usd);
+            }
+            else if (volume_node.is_null()) 
+            {
+                SPDLOG_WARN("Volume value is null for {}", ticker);
+            }
+            else
+            {
+                SPDLOG_WARN("Volume value is not a number for {}: {}", ticker, volume_node.type_name());
             }
         }
         else
         {
-            SPDLOG_WARN("Empty 24hr volume data for {}", defi_ticker_stats.dump(4));
+            SPDLOG_WARN("No volume data available for {}", ticker);
         }
         return volume_24h_usd;
+    }
+
+    std::string
+    global_defi_stats_service::get_trades_24h(const std::string& base, const std::string& quote) const
+    {
+        std::string trades_24h = "0";
+        auto ticker = base + "_" + quote;
+        auto ticker_reversed = quote + "_" + base;
+        SPDLOG_INFO("Getting 24hr trade data for {}", ticker);
+
+        // Check if base/quote are the same
+        if (base == quote)
+        {
+            SPDLOG_INFO("Base/quote must be different, no volume data for {}", ticker);
+            return trades_24h;
+        }
+
+        // Check if defi_stats_volumes is valid
+        auto defi_stats_volumes = m_defi_stats_volumes.get();
+        if (!defi_stats_volumes.is_object())
+        {
+            SPDLOG_WARN("Invalid defi stats volumes data.");
+            return trades_24h;
+        }
+        
+        // Check if volumes key exists
+        if (!defi_stats_volumes.contains("volumes"))
+        {
+            SPDLOG_WARN("No volumes data available.");
+            return trades_24h;
+        }
+
+        // Extract ticker trade_volume_usd safely
+        if (defi_stats_volumes.at("volumes").contains(ticker))
+        {
+            auto trades_node = defi_stats_volumes["volumes"][ticker]["ALL"]["trades_24hr"];
+            if (trades_node.is_number())
+            {
+                trades_24h = std::to_string(trades_node.get<int>());
+                SPDLOG_INFO("{} trades_24h: {}", ticker, trades_24h);
+            }
+            else if (trades_node.is_null()) 
+            {
+                SPDLOG_WARN("Trades value is null for {}", ticker);
+            }
+            else
+            {
+                SPDLOG_WARN("Trades value is not a number for {}: {}", ticker, trades_node.type_name());
+            }
+        }
+        else if (defi_stats_volumes["volumes"].contains(ticker_reversed))
+        {
+            auto trades_node = defi_stats_volumes["volumes"][ticker_reversed]["ALL"]["trades_24hr"];
+            if (trades_node.is_number())
+            {
+                trades_24h = std::to_string(trades_node.get<int>());
+                SPDLOG_INFO("{} trades_24h: {}", ticker_reversed, trades_24h);
+            }
+            else if (trades_node.is_null()) 
+            {
+                SPDLOG_WARN("Trades value is null for {}", ticker);
+            }
+            else
+            {
+                SPDLOG_WARN("Trades value is not a number for {}: {}", ticker, trades_node.type_name());
+            }
+        }
+        else
+        {
+            SPDLOG_WARN("No trades data available for {}", ticker);
+        }
+        return trades_24h;
     }
 } // namespace atomic_dex

--- a/src/core/atomicdex/services/price/defi.stats.hpp
+++ b/src/core/atomicdex/services/price/defi.stats.hpp
@@ -24,18 +24,18 @@
 
 namespace atomic_dex::mm2
 {
-    struct defi_ticker_stats_answer
+    struct defi_stats_volumes_answer
     {
         nlohmann::json                 result;
         int                            status_code;
     };
-    void from_json(const nlohmann::json& j, defi_ticker_stats_answer& answer);
+    void from_json(const nlohmann::json& j, defi_stats_volumes_answer& answer);
 } // namespace atomic_dex::mm2
 
 
 namespace atomic_dex
 {
-    using t_defi_ticker_stats_answer         = mm2::defi_ticker_stats_answer;
+    using t_defi_stats_volumes_answer         = mm2::defi_stats_volumes_answer;
 } // namespace atomic_dex
 
 namespace atomic_dex
@@ -49,7 +49,7 @@ namespace atomic_dex
 
         //! Private member fields
         ag::ecs::system_manager&          m_system_manager;
-        t_json_synchronized               m_defi_ticker_stats;
+        t_json_synchronized               m_defi_stats_volumes;
         t_defi_stats_time_point           m_update_clock;
 
         //! private functions
@@ -67,6 +67,7 @@ namespace atomic_dex
 
         //! Public API
         void                  process_defi_stats();
+        std::string           get_trades_24h(const std::string& base, const std::string& quote) const;
         std::string           get_volume_24h_usd(const std::string& base, const std::string& quote) const;
 
         


### PR DESCRIPTION
Before:
![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/84a4b820-d6f6-42fb-b838-25128c5ed9cc)

After:
![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/79c3da86-6496-4fa8-8c99-52c12cd44a13)

To test:
- Check a few random pairs in dex pro view.
- If pair has stats data at https://defi-stats.komodo.earth/api/v3/pairs/volumes_24hr it should display below the orderbook.
- If pair is not within the data from that endpoint, there have been no trades in the last 24 hours and there should be no stats shown under the orderbook.