### PR TITLE
open lcw when chart is clicked

### DIFF
--- a/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
+++ b/atomic_defi_design/Dex/Exchange/ProView/Chart.qml
@@ -70,6 +70,7 @@ Item
                         transform: scale(${Math.min(scale_x, scale_y)});
                         transform-origin: top left;
                     }
+                    a { pointer-events: none; }
                 </style>
                 <script defer src="https://www.livecoinwatch.com/static/lcw-widget.js"></script>
                 <div class="livecoinwatch-widget-1" lcw-coin="${rel_ticker}" lcw-base="${base_ticker}" lcw-secondary="USDC" lcw-period="w" lcw-color-tx="${Dex.CurrentTheme.foregroundColor}" lcw-color-pr="#58c7c5" lcw-color-bg="${Dex.CurrentTheme.comboBoxBackgroundColor}" lcw-border-w="0" lcw-digits="8" ></div>
@@ -222,6 +223,16 @@ Item
                     webEngineViewPlaceHolder.visible = true
                 }
                 else webEngineViewPlaceHolder.visible = false
+            }
+        }
+    }
+
+    MouseArea {
+        id: chart_mousearea
+        anchors.fill: webEngineViewPlaceHolder
+        onClicked: {
+            if (webEngineView.visible) {
+                Qt.openUrlExternally("https://www.livecoinwatch.com")
             }
         }
     }


### PR DESCRIPTION
Closes: https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2418

To test:
- login and go to DEX tab
- select a pair which shows a chart
- click anywhere on the chart
- see https://www.livecoinwatch.com/ open in a tab in your default browser.

Known issues/limitations:
- As the chart code is generated by 3rd party JS, we cant just change how the hyperlink in the bottom left corner responds when clicked on, so instead the whole chart area is now "active" - you can click anywhere on the chart and it will open LCW.
