### PR TITLE
Fix/simple dex testcoins

### DIFF
--- a/atomic_defi_design/Dex/Exchange/Trade/BestOrder/ListDelegate.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/BestOrder/ListDelegate.qml
@@ -14,8 +14,7 @@ import AtomicDEX.MarketMode 1.0
 Item
 {
     id: _control
-
-    property bool coinEnable: API.app.portfolio_pg.global_cfg_mdl.get_coin_info(coin).is_enabled
+    property bool _isCoinEnabled: API.app.portfolio_pg.global_cfg_mdl.get_coin_info(coin).is_enabled
     property bool isAsk
 
     AnimatedRectangle
@@ -46,7 +45,7 @@ Item
                 height: 24
                 anchors.verticalCenter: parent.verticalCenter
                 source: General.coinIcon(coin)
-                opacity: !_control.coinEnable? .1 : 1
+                opacity: !_control._isCoinEnabled? .1 : 1
             }
 
             Dex.Text
@@ -137,7 +136,7 @@ Item
                 {
                     if (API.app.enable_coins([coin]) === true)
                     {
-                        _control.coinEnable = true;
+                        _control._isCoinEnabled = true;
                         _tooltip.close();
                     }
                     else {

--- a/src/core/atomicdex/config/coins.cfg.cpp
+++ b/src/core/atomicdex/config/coins.cfg.cpp
@@ -286,21 +286,21 @@ namespace atomic_dex
         {
         case CoinType::QRC20:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "tQTUM" : "QTUM";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "tQTUM" : "QTUM";
             break;
         case CoinType::ERC20:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "ETHR" : "ETH";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "ETHR" : "ETH";
             cfg.is_erc_family          = true;
             break;
         case CoinType::BEP20:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "BNBT" : "BNB";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "BNBT" : "BNB";
             cfg.is_erc_family          = true;
             break;
         case CoinType::PLG20:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "MATICTEST" : "MATIC";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "MATICTEST" : "MATIC";
             cfg.is_erc_family          = true;
             break;
         case CoinType::Optimism:
@@ -320,62 +320,62 @@ namespace atomic_dex
             break;
         case CoinType::AVX20:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "AVAXT" : "AVAX";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "AVAXT" : "AVAX";
             cfg.is_erc_family          = true;
             break;
         case CoinType::FTM20:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "FTMT" : "FTM";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "FTMT" : "FTM";
             cfg.is_erc_family          = true;
             break;
         case CoinType::HRC20:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "ONET" : "ONE";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "ONET" : "ONE";
             cfg.is_erc_family          = true;
             break;
         case CoinType::Ubiq:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "UBQT" : "UBQ";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "UBQT" : "UBQ";
             cfg.is_erc_family          = true;
             break;
         case CoinType::KRC20:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "KCST" : "KCS";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "KCST" : "KCS";
             cfg.is_erc_family          = true;
             break;
         case CoinType::Moonriver:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "MOVRT" : "MOVR";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "MOVRT" : "MOVR";
             cfg.is_erc_family          = true;
             break;
         case CoinType::Moonbeam:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "GLMRT" : "GLMR";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "GLMRT" : "GLMR";
             cfg.is_erc_family          = true;
             break;
         case CoinType::HecoChain:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "HTT" : "HT";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "HTT" : "HT";
             cfg.is_erc_family          = true;
             break;
         case CoinType::SmartBCH:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "SBCHT" : "SBCH";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "SBCHT" : "SBCH";
             cfg.is_erc_family          = true;
             break;
         case CoinType::EthereumClassic:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "ETCT" : "ETC";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "ETCT" : "ETC";
             cfg.is_erc_family          = true;
             break;
         case CoinType::RSK:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "RBTCT" : "RBTC";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "RBTCT" : "RBTC";
             cfg.is_erc_family          = true;
             break;
         case CoinType::SLP:
             cfg.has_parent_fees_ticker = true;
-            cfg.fees_ticker            = cfg.is_testnet.value() ? "tBCH" : "BCH";
+            cfg.fees_ticker            = cfg.is_testnet.value_or(false) ? "tBCH" : "BCH";
             break;
         case CoinType::TENDERMINT:
             cfg.has_parent_fees_ticker = true;

--- a/src/core/atomicdex/models/qt.orderbook.proxy.model.cpp
+++ b/src/core/atomicdex/models/qt.orderbook.proxy.model.cpp
@@ -167,6 +167,10 @@ namespace atomic_dex
                 {
                     return false;
                 }
+                if (coin_info.is_testnet)
+                {
+                    break;
+                }
                 if (is_cex_id_available && (rates > 100 || fiat_price <= 0 || ((safe_float(volume) < limit) && coin_info.coin_type != CoinType::SmartChain)))
                 {
                     return false;

--- a/src/core/atomicdex/models/qt.orderbook.proxy.model.cpp
+++ b/src/core/atomicdex/models/qt.orderbook.proxy.model.cpp
@@ -155,27 +155,34 @@ namespace atomic_dex
             case orderbook_model::kind::bids:
                 break;
             case orderbook_model::kind::best_orders:
-                t_float_50  rates      = safe_float(this->sourceModel()->data(idx, orderbook_model::CEXRatesRole).toString().toStdString());
-                t_float_50  fiat_price = safe_float(this->sourceModel()->data(idx, orderbook_model::PriceFiatRole).toString().toStdString());
-                std::string ticker     = this->sourceModel()->data(idx, orderbook_model::CoinRole).toString().toStdString();
-                const auto& provider   = this->m_system_mgr.get_system<komodo_prices_provider>();
-                const auto  coin_info  = this->m_system_mgr.get_system<portfolio_page>().get_global_cfg()->get_coin_info(ticker);
                 t_float_50  limit("10000");
+                t_float_50  rates               = safe_float(this->sourceModel()->data(idx, orderbook_model::CEXRatesRole).toString().toStdString());
+                t_float_50  fiat_price          = safe_float(this->sourceModel()->data(idx, orderbook_model::PriceFiatRole).toString().toStdString());
                 bool        is_cex_id_available = this->sourceModel()->data(idx, orderbook_model::HaveCEXIDRole).toBool();
-                const auto  volume = provider.get_total_volume(utils::retrieve_main_ticker(ticker));
+                const auto& provider            = this->m_system_mgr.get_system<komodo_prices_provider>();
+                std::string ticker              = this->sourceModel()->data(idx, orderbook_model::CoinRole).toString().toStdString();
+                const auto  coin_info           = this->m_system_mgr.get_system<portfolio_page>().get_global_cfg()->get_coin_info(ticker);
+                const auto  volume              = provider.get_total_volume(utils::retrieve_main_ticker(ticker));
+                std::string left_ticker         = this->m_system_mgr.get_system<trading_page>().get_market_pairs_mdl()->get_left_selected_coin().toStdString();
+                const auto  left_coin_info      = this->m_system_mgr.get_system<portfolio_page>().get_global_cfg()->get_coin_info(left_ticker);
+
                 if (coin_info.ticker.empty() || coin_info.wallet_only) //< this means it's not present in our cfg - skipping
                 {
                     return false;
                 }
-                if (coin_info.is_testnet)
+                if (left_coin_info.is_testnet.value_or(false))
                 {
-                    break;
+                    if (coin_info.is_testnet.value_or(false))
+                    {
+                        return true;
+                    }
+                    return false;
                 }
                 if (is_cex_id_available && (rates > 100 || fiat_price <= 0 || ((safe_float(volume) < limit) && coin_info.coin_type != CoinType::SmartChain)))
                 {
                     return false;
                 }
-                break;
+                return true;
             }
         }
 

--- a/src/core/atomicdex/services/mm2/mm2.service.cpp
+++ b/src/core/atomicdex/services/mm2/mm2.service.cpp
@@ -3019,7 +3019,7 @@ namespace atomic_dex
         const coin_config_t            cfg = this->get_coin_info(ticker);
         if (cfg.coin_type == CoinType::QRC20)
         {
-            if (cfg.is_testnet.value())
+            if (cfg.is_testnet.value_or(false))
             {
                 SPDLOG_INFO("{} is from testnet picking tQTUM electrum", ticker);
                 servers = std::move(get_coin_info("tQTUM").electrum_urls.value());


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2369

To Test (pro view):
- Select DOC in the left combo selector on dex pro page.
- Select MARTY in right combo selector on dex pro page.
- Click on an order in the orderbook
- See only testcoins listed in bestorders box

![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/580ccac6-4925-4ae8-ba0c-c035414521f8)


To Test (simple view):
- Select DOC to sell in simple dex view.
- Enter a value to sell
- Expand the buy coin selection list
- See only testcoins listed in buy coin selection list

![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/5f08f48d-9407-4147-a9ae-ad6afd89e4b2)


Inverted test (pro):
- Testcoins should also be excluded from bestorder response for coins with value. I've set up a maker order for MARTY -> PANDA to help test this.
- First confirm the PND/MARTY order exists. If it doesn't, pinf me and I'll create another one.

![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/46db6704-be4e-46bc-b4a6-8970b14a4dcb)

- Next, select PND in left combo in pro view, and click on an order in the orderbook to show the bestorders. 
- MARTY should be excluded from the list.

![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/5addade7-99fa-4625-bc02-dc55e8700aa1)

Inverted test (simple):
- Select PND to sell in simple dex view (if you have no PND balance, do a small trade to get some, its cheap).
- enter an amount to sell to activate the buy section.
- Confirm MARTY does not appear in the buy coin selection list.
![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/54622dda-0dc8-432e-abeb-1a96f9dbe9d4)

**NOTE**: Pro view has since been updated to the new tabbed orderbook/bestorders layout, so the screenshots above are indicative but not how app currently looks. Updated view below for reference.

https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/134690cc-e2f0-4a28-8324-eb9de6cc9287


