### PR TITLE
Fix menubar currency change

### DIFF
--- a/src/core/atomicdex/models/qt.portfolio.model.cpp
+++ b/src/core/atomicdex/models/qt.portfolio.model.cpp
@@ -109,6 +109,8 @@ namespace atomic_dex
     bool
     portfolio_model::update_activation_status()
     {
+        // This feels a bit heavy handed. There should be a better way to do this.
+        // Function may be unused.
         const auto&        mm2_system    = this->m_system_manager.get_system<mm2_service>();
         const auto         coins         = this->m_system_manager.get_system<portfolio_page>().get_global_cfg()->get_enabled_coins();
 

--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -735,7 +735,7 @@ namespace atomic_dex
 
             nlohmann::json json_data = mm2::template_request("withdraw", true);
             mm2::to_json(json_data, withdraw_req);
-            SPDLOG_DEBUG("final json: {}", json_data.dump(4));
+
             batch.push_back(json_data);
 
             std::string amount_std = amount.toStdString();

--- a/src/core/atomicdex/services/price/global.provider.cpp
+++ b/src/core/atomicdex/services/price/global.provider.cpp
@@ -99,15 +99,18 @@ namespace atomic_dex
     global_price_service::refresh_other_coins_rates(
         const std::string& quote_id, const std::string& ticker, bool with_update_providers, std::atomic_uint16_t nb_try)
     {
-        // nb_try += 1;
-        // TODO: Paprika price conversion removed, needs to be replaced
-        nb_try = 10;
-        SPDLOG_INFO("refresh_other_coins_rates - try {}", nb_try.load());
-        if (nb_try == 10)
+        t_float_50 price = safe_float(get_rate_conversion("USD", ticker, true));
+        if (price <= 0)
         {
-            SPDLOG_WARN("refresh other coins rates max try reached, skipping");
-            return;
+            SPDLOG_ERROR("Price is 0 for ticker: {}", ticker);
+            this->m_coin_rate_providers[ticker] = "0.00";
         }
+        else
+        {
+            t_float_50 rate = 1 / price;
+            this->m_coin_rate_providers[ticker] = rate.str();
+        }
+        
     }
 
     global_price_service::global_price_service(entt::registry& registry, ag::ecs::system_manager& system_manager, atomic_dex::cfg& cfg) :
@@ -140,14 +143,14 @@ namespace atomic_dex
     {
         if (fiat == utils::retrieve_main_ticker(ticker_in))
         {
-            return "1";
+            return "1.00";
         }
         std::string ticker =  utils::retrieve_main_ticker(ticker_in);
         try
         {
             //! FIXME: fix zatJum crash report, frontend QML try to retrieve price before program is even launched
             if (ticker.empty())
-                return "0";
+                return "0.00";
             auto&       provider        = m_system_manager.get_system<komodo_prices_provider>();
             std::string current_price   = provider.get_rate_conversion(ticker);
 
@@ -182,7 +185,7 @@ namespace atomic_dex
                 {
                     if (current_price_f < 1.0)
                     {
-                        default_precision = 5;
+                        default_precision = 8;
                     }
                 }
                 //! Trick: If there conversion in a fixed representation is 0.00 then use a default precision to 2 without fixed ios flags


### PR DESCRIPTION
Closes: https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2444

This affects the price display on all pages of the app, wherever a non standard reference currency is selected via a click on the menubar.

To Test, select a range of fiat currencies (via settings) and reference currencies (via the menu bar) and navigate through the app pages to ensure all price info displayed is sane.

