### PR TITLE
more triggers to scroll asks to bottom in pro orderbook

### DIFF
--- a/atomic_defi_design/Dex/Exchange/Trade/OrderBook/List.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/OrderBook/List.qml
@@ -72,16 +72,28 @@ Item
     }
 
     Connections {
-        target: API.app.trading_pg
+        target: API.app.trading_pg;
 
-        function onMarketModeChanged: {
-            if (isAsk)  quickscroll_timer.start()
+        function onMarketModeChanged()
+        {
+            if (isAsk)
+            {
+                quickscroll_timer.start()
+            }
         }
-        function onOrderbookChanged: {
-            if (isAsk)  quickscroll_timer.start()
+        function onOrderbookChanged()
+        {
+            if (isAsk)
+            {
+                quickscroll_timer.start()
+            }
         }
-        function onMarketPairsChanged: {
-            if (isAsk)  quickscroll_timer.start()
+        function onMarketPairsChanged()
+        {
+            if (isAsk)
+            {
+                quickscroll_timer.start()
+            }
         }
     }
 }

--- a/atomic_defi_design/Dex/Exchange/Trade/OrderBook/List.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/OrderBook/List.qml
@@ -73,13 +73,14 @@ Item
 
     Connections {
         target: API.app.trading_pg
-        onMarketModeChanged: {
+
+        function onMarketModeChanged: {
             if (isAsk)  quickscroll_timer.start()
         }
-        onOrderbookChanged: {
+        function onOrderbookChanged: {
             if (isAsk)  quickscroll_timer.start()
         }
-        onMarketPairsChanged: {
+        function onMarketPairsChanged: {
             if (isAsk)  quickscroll_timer.start()
         }
     }

--- a/atomic_defi_design/Dex/Exchange/Trade/OrderBook/List.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/OrderBook/List.qml
@@ -12,7 +12,6 @@ Item
     id: _control
 
     property bool isAsk
-    property bool isVertical: false
     width: parent.width
     height: parent.height
 
@@ -29,7 +28,11 @@ Item
 
         onContentHeightChanged:
         {
-            if (isVertical) _tm.start();
+            if (isAsk){
+                // Duplication is intended. Sometimes data takes too long to load so slowscroll is a backup. 
+                slowscroll_timer.start();
+                quickscroll_timer.start()
+            } 
         }
 
         delegate: Item
@@ -47,12 +50,37 @@ Item
 
         Timer
         {
-            id: _tm
-            interval: 2000
+            id: slowscroll_timer
+            interval: 1500
             onTriggered:
             {
                 orderbook_list.positionViewAtEnd()
             }
+        }
+        Timer
+        {
+            id: quickscroll_timer
+            interval: 500
+            onTriggered:
+            {
+                orderbook_list.positionViewAtEnd()
+            }
+        }
+        onModelChanged: {
+            if (isAsk) quickscroll_timer.start()
+        }
+    }
+
+    Connections {
+        target: API.app.trading_pg
+        onMarketModeChanged: {
+            if (isAsk)  quickscroll_timer.start()
+        }
+        onOrderbookChanged: {
+            if (isAsk)  quickscroll_timer.start()
+        }
+        onMarketPairsChanged: {
+            if (isAsk)  quickscroll_timer.start()
         }
     }
 }

--- a/atomic_defi_design/Dex/Exchange/Trade/OrderBook/Vertical.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/OrderBook/Vertical.qml
@@ -29,7 +29,6 @@ Widget
     List
     {
         isAsk: true
-        isVertical: true
         Layout.fillHeight: true
         Layout.fillWidth: true
     }


### PR DESCRIPTION
DocAgnew on discord reported cases where the asks (in red) for the pro orderbook would not scroll to the bottom so the center point price in the bid/ask lists were tightened.

This PR adds a few additional triggers and timer delays to ensure this scroll is enforced once orderbook loads when 
- flipping pair
- changing pair
- changing buy/sell mode
- loading dex pro tab.

To test:
- login and go to pro screen. 
- select a pair with enough orders to extend the list beyond the window (e.g. KMD/LTC)
- flip the pair, change the pair, change buy to sell change tab and change back. For all of these the values in the top sectiopn oif the orderbook (in red) should scroll down fairly quickly after loading so that the values at the bottom of the red list are as close to the values at the top of the green list as possible.

For example: This is good
![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/b8f852f8-26ca-4099-bb9c-0eff6dfd444d)


And this is not (unless manually scrolled after loading)
![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/e1f9845e-6724-429d-9786-b6f7579706fe)


