### PR TITLE
Add setting to show orders view after placing an order

### DIFF
--- a/assets/config/cfg.json
+++ b/assets/config/cfg.json
@@ -1,6 +1,7 @@
 {
   "notification_enabled": true,
   "spamfilter_enabled": false,
+  "postorder_enabled": false,  
   "use_static_rpcpass": false,
   "current_currency": "USD",
   "current_fiat": "USD",

--- a/atomic_defi_design/Dex/Exchange/Trade/ProView.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/ProView.qml
@@ -102,7 +102,11 @@ RowLayout
                            General.prettifyJSON(response.result), false)
 
                 General.prevent_coin_disabling.restart()
-                tradingInfo.currentIndex = 1
+                // Show the orders tab unless settings say otherwise
+                if (API.app.settings_pg.postorder_enabled)
+                {
+                    tradingInfo.currentIndex = 1
+                }
             }
         }
     }

--- a/atomic_defi_design/Dex/Exchange/Trade/SimpleView/Main.qml
+++ b/atomic_defi_design/Dex/Exchange/Trade/SimpleView/Main.qml
@@ -29,7 +29,10 @@ Item
         target: exchange_trade
         function onOrderPlaced()
         {
-            currentSubPage = subPages.Orders
+            if (API.app.settings_pg.postorder_enabled)
+            {
+                currentSubPage = subPages.Orders
+            }
         }
     }
 

--- a/atomic_defi_design/Dex/Settings/SettingModal.qml
+++ b/atomic_defi_design/Dex/Settings/SettingModal.qml
@@ -482,6 +482,32 @@ Qaterial.Dialog
                                     }
                                 }
                             }
+                            
+                            // Post-order placement toggle
+                            RowLayout
+                            {
+                                width: parent.width - 30
+                                anchors.horizontalCenter: parent.horizontalCenter
+                                height: 50
+
+                                DexLabel
+                                {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    Layout.fillWidth: true
+                                    font: DexTypo.subtitle1
+                                    text: qsTr("Show orders after placement")
+                                }
+
+                                Item { Layout.fillWidth: true }
+
+                                DexSwitch
+                                {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    Component.onCompleted: checked = API.app.settings_pg.postorder_enabled
+                                    onCheckedChanged: API.app.settings_pg.postorder_enabled = checked
+                                }
+                            }
+
                         }
                     }
                     Item

--- a/src/core/atomicdex/config/app.cfg.cpp
+++ b/src/core/atomicdex/config/app.cfg.cpp
@@ -50,6 +50,7 @@ namespace
         config_json_data["available_signs"]         = config.available_currency_signs;
         config_json_data["notification_enabled"]    = config.notification_enabled;
         config_json_data["spamfilter_enabled"]      = config.spamfilter_enabled;
+        config_json_data["postorder_enabled"]       = config.postorder_enabled;
         config_json_data["static_rpcpass_enabled"]  = config.static_rpcpass_enabled;
 
         file.close();
@@ -85,6 +86,15 @@ namespace atomic_dex
             config.spamfilter_enabled = true;
         }
 
+        if (j.contains("postorder_enabled"))
+        {
+            j.at("postorder_enabled").get_to(config.postorder_enabled);
+        }
+        else
+        {
+            config.postorder_enabled = true;
+        }
+
         if (j.contains("static_rpcpass_enabled"))
         {
             j.at("static_rpcpass_enabled").get_to(config.static_rpcpass_enabled);
@@ -101,6 +111,16 @@ namespace atomic_dex
         if (config.notification_enabled != is_enabled)
         {
             config.notification_enabled = is_enabled;
+            upgrade_cfg(config);
+        }
+    }
+
+    void
+    change_postorder_status(cfg& config, bool is_enabled)
+    {
+        if (config.postorder_enabled != is_enabled)
+        {
+            config.postorder_enabled = is_enabled;
             upgrade_cfg(config);
         }
     }

--- a/src/core/atomicdex/config/app.cfg.hpp
+++ b/src/core/atomicdex/config/app.cfg.hpp
@@ -32,6 +32,7 @@ namespace atomic_dex
         std::vector<std::string>                     recommended_fiat;
         std::vector<std::string>                     possible_currencies;
         bool                                         notification_enabled;
+        bool                                         postorder_enabled{false};
         bool                                         spamfilter_enabled{false};
         bool                                         static_rpcpass_enabled{false};
     };
@@ -40,6 +41,7 @@ namespace atomic_dex
     void               change_currency(cfg& config, const std::string& new_currency);
     void               change_fiat(cfg& config, const std::string& new_fiat);
     void               change_notification_status(cfg& config, bool is_enabled);
+    void               change_postorder_status(cfg& config, bool is_enabled);
     void               change_spamfilter_status(cfg& config, bool is_enabled);
     void               change_static_rpcpass_status(cfg& config, bool is_enabled);
     [[nodiscard]] bool is_this_currency_a_fiat(const cfg& config, const std::string& currency);

--- a/src/core/atomicdex/pages/qt.settings.page.cpp
+++ b/src/core/atomicdex/pages/qt.settings.page.cpp
@@ -226,6 +226,20 @@ namespace atomic_dex
         }
     }
 
+    bool atomic_dex::settings_page::is_postorder_enabled() const
+    {
+        return m_config.postorder_enabled;
+    }
+
+    void settings_page::set_postorder_enabled(bool is_enabled)
+    {
+        if (m_config.postorder_enabled != is_enabled)
+        {
+            change_postorder_status(m_config, is_enabled);
+            emit onPostOrderEnabledChanged();
+        }
+    }
+
     bool atomic_dex::settings_page::is_notification_enabled() const
     {
         return m_config.notification_enabled;

--- a/src/core/atomicdex/pages/qt.settings.page.hpp
+++ b/src/core/atomicdex/pages/qt.settings.page.hpp
@@ -46,6 +46,7 @@ namespace atomic_dex
         Q_PROPERTY(QString  current_fiat                    READ get_current_fiat                   WRITE set_current_fiat                      NOTIFY onFiatChanged)
         Q_PROPERTY(bool     notification_enabled            READ is_notification_enabled            WRITE set_notification_enabled              NOTIFY onNotificationEnabledChanged)
         Q_PROPERTY(bool     spamfilter_enabled              READ is_spamfilter_enabled              WRITE set_spamfilter_enabled                NOTIFY onSpamFilterEnabledChanged)
+        Q_PROPERTY(bool     postorder_enabled               READ is_postorder_enabled               WRITE set_postorder_enabled                 NOTIFY onPostOrderEnabledChanged)
         Q_PROPERTY(bool     static_rpcpass_enabled          READ is_static_rpcpass_enabled          WRITE set_static_rpcpass_enabled            NOTIFY onStaticRpcPassEnabledChanged)
         Q_PROPERTY(QVariant custom_token_data               READ get_custom_token_data              WRITE set_custom_token_data                 NOTIFY customTokenDataChanged)
         Q_PROPERTY(bool     fetching_custom_token_data_busy READ is_fetching_custom_token_data_busy WRITE set_fetching_custom_token_data_busy   NOTIFY customTokenDataStatusChanged)
@@ -94,6 +95,8 @@ namespace atomic_dex
         bool                                    set_zhtlc_status(nlohmann::json data);
         [[nodiscard]] bool                      is_spamfilter_enabled() const;
         void                                    set_spamfilter_enabled(bool is_enabled);
+        [[nodiscard]] bool                      is_postorder_enabled() const;
+        void                                    set_postorder_enabled(bool is_enabled);
         void                                    set_current_currency(const QString& current_currency);
         void                                    set_current_fiat(const QString& current_fiat);
         [[nodiscard]] bool                      is_fetching_custom_token_data_busy() const;
@@ -143,6 +146,7 @@ namespace atomic_dex
         void onFiatSignChanged();
         void onFiatChanged();
         void onNotificationEnabledChanged();
+        void onPostOrderEnabledChanged();
         void onSpamFilterEnabledChanged();
         void onStaticRpcPassEnabledChanged();
         void customTokenDataChanged();


### PR DESCRIPTION
Pana.BLK requested in discord to not automatically show the orders tab after placing an order (preferring to remain on the chart view. Previously a different user requested the opposite. To cater to the widest user preference, I've delegated this to a toggle in settings as below:
![image](https://github.com/KomodoPlatform/komodo-wallet-desktop/assets/35845239/b16503ae-c924-4ab0-b2f1-a6ca252de6fd)

To Test:
- In  pro view, with the chart visible, place an order while the toggle is active. Once the order has been submitted, the chart view should be updated to show the user's active orders.
- Disable the toggle, and make the chart visible again, then place another order. Once the order has been submitted, the chart view should still be visible.
- Repeat the above tests in simple mode. When toggle is active, orders will be shown after placement. When not active, after placement the simple orderform will be shown again.