### PR TITLE
use UtxoPerKbyte for custom utxo fees

### DIFF
--- a/atomic_defi_design/Dex/Wallet/SendModal.qml
+++ b/atomic_defi_design/Dex/Wallet/SendModal.qml
@@ -681,7 +681,7 @@ MultipageModal
                 Layout.preferredHeight: 38
                 Layout.alignment: Qt.AlignHCenter
 
-                placeholderText: qsTr("Enter the custom fee") + " [" + api_wallet_page.ticker + "]"
+                placeholderText: qsTr("Enter the custom fee") + " (" + api_wallet_page.ticker + "/kb)"
             }
 
             // Token coins

--- a/src/core/atomicdex/pages/qt.wallet.page.cpp
+++ b/src/core/atomicdex/pages/qt.wallet.page.cpp
@@ -526,7 +526,7 @@ namespace atomic_dex
                 qDebug() << fees_data;
                 auto json_fees    = nlohmann::json::parse(QString(QJsonDocument(QVariant(fees_data).toJsonObject()).toJson()).toStdString());
                 withdraw_init_req.fees = t_withdraw_init_fees{
-                    .type      = "UtxoFixed",
+                    .type      = "UtxoPerKbyte",
                     .amount    = json_fees.at("fees_amount").get<std::string>()
                 };
             }
@@ -702,7 +702,7 @@ namespace atomic_dex
             {
                 qDebug() << fees_data;
                 withdraw_req.fees = t_withdraw_fees{
-                    .type      = "UtxoFixed",
+                    .type      = "UtxoPerKbyte",
                     .amount    = json_fees.at("fees_amount").get<std::string>(),
                     .gas_limit = json_fees.at("gas_limit").get<int>()};
                 if (coin_info.coin_type == CoinType::ERC20)


### PR DESCRIPTION
closes https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/11

To test:
- Go to withdraw DOC or MARTY 
- Toggle on the custom fee input
- Set custom fee to `1`
- Send the withdraw
- Check the transaction on the block explorer. Under `Summary > Size` it will show the kb size of the transaction in bytes. Divide by 1024 for kb.
- Confirm transaction fee is `size / 1024`